### PR TITLE
0.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,20 +4,23 @@ L-systems renderer in Exponential Idle.
 
 ## Features
 
-- Supports 3D drawing
 - Can store a whole army of systems!
-- Two camera modes: fixed (scaled) and cursor-focused
-- Stroke options
+- Stochastic (randomised) and 3D systems
+- Camera modes: static and cursor-focused (lerp)
+- Speed and stroke options
+
+Warning: As of v0.18, the renderer's configuration will `be messed up` due to
+format changes to the internal state.
 
 ## Installation
 
-Current version: 0.18.2
+Current version: 0.19
 
 Navigate to [`renderer.js`](./renderer.js) and click on `Raw`. You will be
 delivered to this theory's raw code. Copy the page's URL.
 
 Then, access the custom theory panel within the game (unlocked after finishing
-the Convergence Test) then enter the picking menu. Press the plus symbol and
+the Convergence Test) then enter the picking menu. Press the `+` symbol and
 paste the URL in.
 
 ## Screenshots

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,10 @@
 # L-systems Renderer
 
-## 0.19: Winter Sweep
+## 0.20: Spring Cleaning
+
+- Context sensitivity
+  - `b < a > c → aa`
+  - How to store? Maps?
 
 - Add more comments in the code
 - Add more systems to the manual (algae)
@@ -10,22 +14,13 @@
   - Like a blog post, sort of
   - Post to reddit `r/proceduralgeneration`, crosspost `r/lsystem`
 
-- Saved systems can also store static camera configs like manual pages?
-  - Technically not possible currently
-  - Storing descriptions is also probably not possible
-  - Unless we have the power of version number
-
-- Version number: helps migrating settings
-
-## 0.20: Spring Cleaning
-
-- Context sensitivity
-  - `b < a > c → aa`
-  - How to store? Maps?
-
 ## Currently Impossible
 
 - Remove the add button, every rule is bunched into one field
   - Entry.keyboard? (`Keyboard.TEXT`) doesn't work
   - https://andyp.dev/posts/xamarin-forms-essentials-keyboard-master-guide
   - Which means, adding extra processing in view menu and system menu
+- Saved systems can also store static camera configs like manual pages?
+  - Technically not possible currently
+  - Storing descriptions is also probably not possible
+  - Unless we have the power of version number

--- a/TODO.md
+++ b/TODO.md
@@ -16,16 +16,6 @@
   - Storing descriptions is also probably not possible
   - Unless we have the power of version number
 
-- Slow string processing to avoid erroring, by returning a status object in
-`LSystem.derive()`
-  - Add a starting point argument to derive()
-  - Add a ready bool to Renderer
-    - In draw(), the first level difference check sets ready to false
-    - If the update is done, set ready to true
-    - Ready check happens after the elapsed == 0 check
-    - How to store Renderer.update()'s status?
-  - While the current level is updating, drawing can resume? (LUXURY)
-
 - Playlist queueing system, which will help with future endeavours
   - Mode 0 doesn't do anything, mode 1 queues the same thing, mode 2 queues next
   - Not really a queue, just a 'next' number

--- a/TODO.md
+++ b/TODO.md
@@ -12,7 +12,6 @@
   - Showcases the power of tickspeed and stroke options
   - Discusses limitations of the game
   - Like a blog post, sort of
-  - Post to reddit `r/proceduralgeneration`, crosspost `r/lsystem`
 
 ## Currently Impossible
 

--- a/TODO.md
+++ b/TODO.md
@@ -3,20 +3,19 @@
 ## 0.19: Spring Cleaning
 
 - Add more comments in the code
+- Add more systems to the manual (algae)
+- Move all strings to global scope for translations!
 - A more detailed README
   - Showcases the power of tickspeed and stroke options
   - Discusses limitations of the game
   - Like a blog post, sort of
   - Post to reddit `r/proceduralgeneration`, crosspost `r/lsystem`
 
-- Playlist queueing system, which will help with future endeavours
-  - Mode 0 doesn't do anything, mode 1 queues the same thing, mode 2 queues next
-- Add more systems to the manual (algae)
 - Saved systems can also store static camera configs like manual pages?
   - Technically not possible currently
   - Storing descriptions is also probably not possible
   - Unless we have the power of version number
-- Move all strings to global scope for translations!
+
 - Slow string processing to avoid erroring, by returning a status object in
 `LSystem.derive()`
   - Add a starting point argument to derive()
@@ -25,6 +24,11 @@
     - If the update is done, set ready to true
     - Ready check happens after the elapsed == 0 check
     - How to store Renderer.update()'s status?
+  - While the current level is updating, drawing can resume? (LUXURY)
+
+- Playlist queueing system, which will help with future endeavours
+  - Mode 0 doesn't do anything, mode 1 queues the same thing, mode 2 queues next
+  - Not really a queue, just a 'next' number
 
 - Version number: helps migrating settings
 - Theory pause button?

--- a/TODO.md
+++ b/TODO.md
@@ -19,6 +19,7 @@
 - Playlist queueing system, which will help with future endeavours
   - Mode 0 doesn't do anything, mode 1 queues the same thing, mode 2 queues next
   - Not really a queue, just a 'next' number
+  - Or just collect the variable level when it ends
 
 - Version number: helps migrating settings
 - Theory pause button?
@@ -27,10 +28,11 @@
 
 - Context sensitivity
   - `b < a > c → aa`
+  - How to store? Maps?
 
 ## Currently Impossible
 
 - Remove the add button, every rule is bunched into one field
-  - Entry.keyboard? (`Keyboard.TEXT`)
+  - Entry.keyboard? (`Keyboard.TEXT`) doesn't work
   - https://andyp.dev/posts/xamarin-forms-essentials-keyboard-master-guide
   - Which means, adding extra processing in view menu and system menu

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,6 @@
 # L-systems Renderer
 
-## 0.19: Spring Cleaning
+## 0.19: Winter Sweep
 
 - Add more comments in the code
 - Add more systems to the manual (algae)
@@ -24,7 +24,7 @@
 - Version number: helps migrating settings
 - Theory pause button?
 
-## 0.20
+## 0.20: Spring Cleaning
 
 - Context sensitivity
   - `b < a > c → aa`

--- a/TODO.md
+++ b/TODO.md
@@ -4,20 +4,27 @@
 
 - Add more comments in the code
 - A more detailed README
-  + Showcases the power of tickspeed and stroke options
-  + Discusses limitations of the game
-  + Like a blog post, sort of
-  + Post to reddit `r/proceduralgeneration`, crosspost `r/lsystem`
+  - Showcases the power of tickspeed and stroke options
+  - Discusses limitations of the game
+  - Like a blog post, sort of
+  - Post to reddit `r/proceduralgeneration`, crosspost `r/lsystem`
 
 - Playlist queueing system, which will help with future endeavours
-  + Mode 0 doesn't do anything, mode 1 queues the same thing, mode 2 queues next
+  - Mode 0 doesn't do anything, mode 1 queues the same thing, mode 2 queues next
 - Add more systems to the manual (algae)
 - Saved systems can also store static camera configs like manual pages?
-  + Technically not possible currently
-  + Storing descriptions is also probably not possible
-  + Unless we have the power of version number
+  - Technically not possible currently
+  - Storing descriptions is also probably not possible
+  - Unless we have the power of version number
 - Move all strings to global scope for translations!
-- Slow string processing to avoid erroring
+- Slow string processing to avoid erroring, by returning a status object in
+`LSystem.derive()`
+  - Add a starting point argument to derive()
+  - Add a ready bool to Renderer
+    - In draw(), the first level difference check sets ready to false
+    - If the update is done, set ready to true
+    - Ready check happens after the elapsed == 0 check
+    - How to store Renderer.update()'s status?
 
 - Version number: helps migrating settings
 - Theory pause button?
@@ -25,11 +32,11 @@
 ## 0.20
 
 - Context sensitivity
-  + `b < a > c → aa`
+  - `b < a > c → aa`
 
 ## Currently Impossible
 
 - Remove the add button, every rule is bunched into one field
-  + Entry.keyboard? (`Keyboard.TEXT`)
-  + https://andyp.dev/posts/xamarin-forms-essentials-keyboard-master-guide
-  + Which means, adding extra processing in view menu and system menu
+  - Entry.keyboard? (`Keyboard.TEXT`)
+  - https://andyp.dev/posts/xamarin-forms-essentials-keyboard-master-guide
+  - Which means, adding extra processing in view menu and system menu

--- a/TODO.md
+++ b/TODO.md
@@ -5,6 +5,8 @@
 - Add more comments in the code
 - Add more systems to the manual (algae)
 - Move all strings to global scope for translations!
+  - Naming system for the loc string names is not consistent rn
+- Store a temp let when refunding/bulk buying a variable that allows you to return to that level
 - A more detailed README
   - Showcases the power of tickspeed and stroke options
   - Discusses limitations of the game

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,35 @@
+# L-systems Renderer
+
+## 0.19: Spring Cleaning
+
+- Add more comments in the code
+- A more detailed README
+  + Showcases the power of tickspeed and stroke options
+  + Discusses limitations of the game
+  + Like a blog post, sort of
+  + Post to reddit `r/proceduralgeneration`, crosspost `r/lsystem`
+
+- Playlist queueing system, which will help with future endeavours
+  + Mode 0 doesn't do anything, mode 1 queues the same thing, mode 2 queues next
+- Add more systems to the manual (algae)
+- Saved systems can also store static camera configs like manual pages?
+  + Technically not possible currently
+  + Storing descriptions is also probably not possible
+  + Unless we have the power of version number
+- Move all strings to global scope for translations!
+- Slow string processing to avoid erroring
+
+- Version number: helps migrating settings
+- Theory pause button?
+
+## 0.20
+
+- Context sensitivity
+  + `b < a > c → aa`
+
+## Currently Impossible
+
+- Remove the add button, every rule is bunched into one field
+  + Entry.keyboard? (`Keyboard.TEXT`)
+  + https://andyp.dev/posts/xamarin-forms-essentials-keyboard-master-guide
+  + Which means, adding extra processing in view menu and system menu

--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,6 @@
 
 - Add more comments in the code
 - Add more systems to the manual (algae)
-- Store a temp let when refunding/bulk buying a variable that allows you to return to that level
 - A more detailed README
   - Showcases the power of tickspeed and stroke options
   - Discusses limitations of the game
@@ -15,11 +14,6 @@
   - Technically not possible currently
   - Storing descriptions is also probably not possible
   - Unless we have the power of version number
-
-- Playlist queueing system, which will help with future endeavours
-  - Mode 0 doesn't do anything, mode 1 queues the same thing, mode 2 queues next
-  - Not really a queue, just a 'next' number
-  - Or just collect the variable level when it ends
 
 - Version number: helps migrating settings
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,6 @@
 # L-systems Renderer
 
-## 0.20: Spring Cleaning
+## 0.20: It Depends
 
 - Context sensitivity
   - `b < a > c → aa`

--- a/TODO.md
+++ b/TODO.md
@@ -22,7 +22,6 @@
   - Or just collect the variable level when it ends
 
 - Version number: helps migrating settings
-- Theory pause button?
 
 ## 0.20: Spring Cleaning
 

--- a/TODO.md
+++ b/TODO.md
@@ -4,8 +4,6 @@
 
 - Add more comments in the code
 - Add more systems to the manual (algae)
-- Move all strings to global scope for translations!
-  - Naming system for the loc string names is not consistent rn
 - Store a temp let when refunding/bulk buying a variable that allows you to return to that level
 - A more detailed README
   - Showcases the power of tickspeed and stroke options

--- a/renderer.js
+++ b/renderer.js
@@ -702,8 +702,11 @@ class Renderer
                     this.stack.push([this.state, this.ori]);
                     break;
                 case ']':
+                    if(this.stack.length == 0)
+                        return;
                     if(this.loopMode == 0 && this.stack.length == 1)
                     {
+                        this.idx = i;
                         return;
                     }
                     let t = this.stack.pop();

--- a/renderer.js
+++ b/renderer.js
@@ -1111,8 +1111,7 @@ var createConfigMenu = () =>
                 text: 'Centre (x, y, z): ',
                 row: 0,
                 column: 0,
-                verticalOptions: LayoutOptions.CENTER,
-                isVisible: !tmpCFC
+                verticalOptions: LayoutOptions.CENTER
             }),
             ui.createEntry
             ({

--- a/renderer.js
+++ b/renderer.js
@@ -152,12 +152,15 @@ const locStrings =
 
 Level: the system's level. Pressing + or - will derive/revert the system ` +
 `respectively. Pressing the Level button will reveal all levels of the system.
+(Tip: holding + or - will buy/refund the variable in bulks of 10.)
 
 Tickspeed: controls the renderer's drawing speed (up to 10 lines/sec, which ` +
 `produces less accurate lines).
-Pressing the Tickspeed button will toggle between Tick delay and Tickspeed ` +
+Pressing the Tickspeed button will toggle between Tickspeed and Tick delay ` +
 `modes.
-(Tip: holding + or - will buy/refund a variable in bulks of 10.)
+(Tip: holding - on Tickspeed will create an 'anchor' and pause the renderer. ` +
+`Holding + afterwards will return the renderer to the previously 'anchored' ` +
+`speed.)
 
 Reroll: located on the top right. Pressing this button will reroll the ` +
 `system's seed (for stochastic systems).`
@@ -1338,7 +1341,7 @@ let page = 0;
 let offlineDrawing = false;
 let gameIsOffline = false;
 let altCurrencies = true;
-let tickDelayMode = true;
+let tickDelayMode = false;
 
 let arrow = new LSystem('X', ['F=FF', 'X=F[+X][-X]FX'], 30);
 let renderer = new Renderer(arrow, 1, 2, false, 1);

--- a/renderer.js
+++ b/renderer.js
@@ -347,6 +347,7 @@ class Renderer
 
     update(level, seedChanged = false)
     {
+        let loop = this.loopMode == 2 && level > this.lvl;
         let start = seedChanged ? 0 : this.levels.length;
         let charCount = 0;
         for(let i = start; i <= level; ++i)
@@ -365,7 +366,8 @@ class Renderer
             }
         }
         this.lvl = level;
-        this.reset();
+        if(!loop)
+            this.reset();
     }
     reset()
     {
@@ -471,6 +473,10 @@ class Renderer
                     this.stack.push([this.state, this.ori]);
                     break;
                 case ']':
+                    if(this.loopMode == 0 && this.stack.length == 1)
+                    {
+                        return;
+                    }
                     let t = this.stack.pop();
                     this.state = t[0];
                     this.ori = t[1];
@@ -481,6 +487,8 @@ class Renderer
                         if(this.idx >= this.levels[this.lvl].length)
                         {
                             this.idx = 0;
+                            if(this.loopMode == 2)
+                                l.buy(1);
                             this.reverse = false;
                         }
                     }
@@ -1185,7 +1193,7 @@ var createConfigMenu = () =>
     let loopModes = ['Off', 'Level', 'Playlist'];
     let ODLabel = ui.createLatexLabel
     ({
-        text: `Loop mode: ${loopModes[tmpOD]}`,
+        text: `Looping mode: ${loopModes[tmpOD]}`,
         row: 0,
         column: 0,
         verticalOptions: LayoutOptions.CENTER
@@ -1202,7 +1210,7 @@ var createConfigMenu = () =>
         onValueChanged: () =>
         {
             tmpOD = Math.round(ODSlider.value);
-            ODLabel.text = `Loop mode: ${loopModes[tmpOD]}`;
+            ODLabel.text = `Looping mode: ${loopModes[tmpOD]}`;
         },
         onDragCompleted: () =>
         {

--- a/renderer.js
+++ b/renderer.js
@@ -8,7 +8,6 @@ import { LayoutOptions } from '../api/ui/properties/LayoutOptions';
 import { TextAlignment } from '../api/ui/properties/TextAlignment';
 import { Thickness } from '../api/ui/properties/Thickness';
 import { TouchType } from '../api/ui/properties/TouchType';
-import { ImageSource } from '../api/ui/properties/ImageSource';
 
 /*
 Disclaimer: The consensus around L-system's grammar is generally not much
@@ -29,26 +28,29 @@ and the Z stands for Zombies.
 (c) 2022 Temple of Pan (R) (TM) All rights reversed.
 */
 
-var id = 'L_systems_renderer';
-var name = 'L-systems Renderer';
-var description = 'An educational tool that lets you draw various fractal ' +
-                  'figures and plants.\n\nFeatures:\n- Can store a whole ' +
-                  'army of systems!\n- Stochastic (randomised) systems\n' +
-                  '- Switch between camera modes: fixed (scaled) and cursor-' +
-                  'focused\n- Stroke options\n\nWarning: As of 0.18, the '+
-                  'renderer\'s configuration will be messed up due to format ' +
-                  'changes to the internal state.';
-var authors = 'propfeds#5988\n\nThanks to:\nSir Gilles-Philippe Paillé, for ' +
-              'providing help with quaternions';
-var versionStr = 'v0.19 WIP';
-var version = 0.182;
-var time = 0;
-var page = 0;
-var offlineDrawing = false;
-var gameIsOffline = false;
-var altCurrencies = true;
-var tickDelayMode = true;
+const id = 'L_systems_renderer';
+const name = 'L-systems Renderer';
+const description = 'An educational tool that lets you draw various fractal ' +
+                    'figures and plants.\n\nFeatures:\n- Can store a whole ' +
+                    'army of systems!\n- Stochastic (randomised) systems\n' +
+                    '- Switch between camera modes: fixed (scaled) and ' +
+                    'cursor-focused\n- Stroke options\n\nWarning: As of 0.18, '+
+                    'the renderer\'s configuration will be messed up due to ' +
+                    'format changes to the internal state.';
+const authors = 'propfeds#5988\n\nThanks to:\nSir Gilles-Philippe Paillé, ' +
+                'for providing help with quaternions';
+const versionStr = 'v0.19 WIP';
+const version = 0.182;
 const MAX_CHARS_PER_TICK = 10000;
+
+/**
+ * Returns a string of a fixed decimal number, with a fairly uniform width.
+ * @returns {string} the string.
+ */
+let getCoordString = (x) => x.toFixed(x >= -0.01 ?
+    (x <= 9.999 ? 3 : (x <= 99.99 ? 2 : 1)) :
+    (x < -9.99 ? (x < -99.9 ? 0 : 1) : 2)
+);
 
 /**
  * Represents a linear congruential generator.
@@ -950,21 +952,20 @@ class Renderer
     }
 }
 
-/**
- * Returns a string of a fixed decimal number, with a fairly uniform width.
- * @returns {string} the string.
- */
-var getCoordString = (x) => x.toFixed(x >= -0.01 ?
-    (x <= 9.999 ? 3 : (x <= 99.99 ? 2 : 1)) :
-    (x < -9.99 ? (x < -99.9 ? 0 : 1) : 2));
+let time = 0;
+let page = 0;
+let offlineDrawing = false;
+let gameIsOffline = false;
+let altCurrencies = true;
+let tickDelayMode = true;
 
-var arrow = new LSystem('X', ['F=FF', 'X=F[+X][-X]FX'], 30);
-var renderer = new Renderer(arrow, 1, 2, false, 1);
+let arrow = new LSystem('X', ['F=FF', 'X=F[+X][-X]FX'], 30);
+let renderer = new Renderer(arrow, 1, 2, false, 1);
 
-var xAxisQuat = new Quaternion(0, 1, 0, 0);
-var globalSeed = new LCG(Date.now());
-var savedSystems = new Map();
-var manualPages =
+let xAxisQuat = new Quaternion(0, 1, 0, 0);
+let globalSeed = new LCG(Date.now());
+let savedSystems = new Map();
+let manualPages =
 [
     {
         title: 'The Main Screen',
@@ -1268,7 +1269,7 @@ Upright`,
     }
 ];
 
-var init = () =>
+let init = () =>
 {
     // if(altCurrencies)
     // {
@@ -1305,7 +1306,11 @@ var init = () =>
         let getDesc = (level) =>
         {
             if(tickDelayMode)
+            {
+                if(level == 0)
+                    return `\\text{Tick delay: }\\infty`;
                 return `\\text{Tick delay: }${(level / 10).toString()}\\text{ sec}`;
+            }
             return `\\text{Tickspeed: }${level.toString()}/\\text{sec}`;
         }
         let getInfo = (level) => `\\text{Ts=}${level.toString()}/s`;
@@ -1326,9 +1331,9 @@ var init = () =>
     );
 }
 
-var alwaysShowRefundButtons = () => true;
+let alwaysShowRefundButtons = () => true;
 
-var timeCheck = (elapsedTime) =>
+let timeCheck = (elapsedTime) =>
 {
     if(ts.level == 0)
         return false;
@@ -1342,7 +1347,7 @@ var timeCheck = (elapsedTime) =>
     return time >= 1 / ts.level - 1e-8
 }
 
-var tick = (elapsedTime, multiplier) =>
+let tick = (elapsedTime, multiplier) =>
 {
     if(timeCheck(elapsedTime))
     {
@@ -1378,7 +1383,7 @@ var tick = (elapsedTime, multiplier) =>
     theory.invalidateTertiaryEquation();
 }
 
-var getEquationOverlay = () =>
+let getEquationOverlay = () =>
 {
     let result = ui.createLatexLabel
     ({
@@ -1391,7 +1396,7 @@ var getEquationOverlay = () =>
     return result;
 }
 
-var createVariableButton = (variable, height) =>
+let createVariableButton = (variable, height) =>
 {
     let frame = ui.createFrame
     ({
@@ -1409,7 +1414,7 @@ var createVariableButton = (variable, height) =>
     return frame;
 }
 
-var createMinusButton = (variable, height, symbol = '-') =>
+let createMinusButton = (variable, height, symbol = '-') =>
 {
     let bc = () => variable.level > 0 ?
     Color.MINIGAME_TILE_BORDER : Color.TRANSPARENT;
@@ -1454,7 +1459,7 @@ var createMinusButton = (variable, height, symbol = '-') =>
     return frame;
 }
 
-var createPlusButton = (variable, height, symbol = '+', quickbuyAmount = 10) =>
+let createPlusButton = (variable, height, symbol = '+', quickbuyAmount = 10) =>
 {
     let bc = () => variable.level < variable.maxLevel ?
     Color.MINIGAME_TILE_BORDER : Color.TRANSPARENT;
@@ -1501,7 +1506,7 @@ var createPlusButton = (variable, height, symbol = '+', quickbuyAmount = 10) =>
     return frame;
 }
 
-var createMenuButton = (menuFunc, name, height) =>
+let createMenuButton = (menuFunc, name, height) =>
 {
     let frame = ui.createFrame
     ({
@@ -1539,7 +1544,7 @@ var createMenuButton = (menuFunc, name, height) =>
 }
 
 // For example: The level variable button opens the sequence menu
-var createClickableVariableButton = (variable, callback, height) =>
+let createClickableVariableButton = (variable, callback, height) =>
 {
     let frame = ui.createFrame
     ({
@@ -1575,7 +1580,7 @@ var createClickableVariableButton = (variable, callback, height) =>
     return frame;
 }
 
-var getUpgradeListDelegate = () =>
+let getUpgradeListDelegate = () =>
 {
     let height = ui.screenHeight * 0.055;
 
@@ -1683,7 +1688,7 @@ var getUpgradeListDelegate = () =>
     return stack;
 }
 
-var createConfigMenu = () =>
+let createConfigMenu = () =>
 {
     let tmpIScale = renderer.initScale;
     let iScaleEntry = ui.createEntry
@@ -2059,7 +2064,7 @@ var createConfigMenu = () =>
     return menu;
 }
 
-var createSystemMenu = () =>
+let createSystemMenu = () =>
 {
     let tmpAxiom = renderer.system.axiom;
     let axiomEntry = ui.createEntry
@@ -2252,7 +2257,7 @@ var createSystemMenu = () =>
     return menu;
 }
 
-var createNamingMenu = (title, values) =>
+let createNamingMenu = (title, values) =>
 {
     let tmpName = title;
     let nameEntry = ui.createEntry
@@ -2294,7 +2299,7 @@ var createNamingMenu = (title, values) =>
     return menu;
 }
 
-var createClipboardMenu = (values) =>
+let createClipboardMenu = (values) =>
 {
     let tmpSys = values;
     let sysEntry = ui.createEntry
@@ -2337,7 +2342,7 @@ var createClipboardMenu = (values) =>
     return menu;
 }
 
-var createViewMenu = (title) =>
+let createViewMenu = (title) =>
 {
     values = savedSystems.get(title);
 
@@ -2509,7 +2514,7 @@ var createViewMenu = (title) =>
     return menu;
 }
 
-var createSaveMenu = () =>
+let createSaveMenu = () =>
 {
     let menu;
     let getSystemGrid = () =>
@@ -2635,7 +2640,7 @@ var createSaveMenu = () =>
     return menu;
 }
 
-var createManualMenu = () =>
+let createManualMenu = () =>
 {
     let pageTitle = ui.createLatexLabel
     ({
@@ -2742,7 +2747,7 @@ var createManualMenu = () =>
     return menu;
 }
 
-var createSequenceMenu = () =>
+let createSequenceMenu = () =>
 {
     let tmpLvls = [];
     for(let i = 0; i < renderer.levels.length; ++i)
@@ -2799,7 +2804,7 @@ var createSequenceMenu = () =>
     return menu;
 }
 
-var createWorldMenu = () =>
+let createWorldMenu = () =>
 {
     let tmpOD = offlineDrawing;
     let ODSwitch = ui.createSwitch
@@ -2893,7 +2898,7 @@ var createWorldMenu = () =>
     return menu;
 }
 
-var getInternalState = () =>
+let getInternalState = () =>
 {
     let result = `${version} ${time} ${page} ${offlineDrawing ? 1 : 0} ${altCurrencies ? 1 : 0} ${tickDelayMode ? 1 : 0}`;
     result += `\n${renderer.toString()}\n${renderer.system.toString()}`;
@@ -2904,7 +2909,7 @@ var getInternalState = () =>
     return result;
 }
 
-var setInternalState = (stateStr) =>
+let setInternalState = (stateStr) =>
 {
     let values = stateStr.split('\n');
 
@@ -2961,21 +2966,21 @@ var setInternalState = (stateStr) =>
         savedSystems.set(values[i], values[i + 1]);
 }
 
-var canResetStage = () => true;
+let canResetStage = () => true;
 
-var getResetStageMessage = () => 'You are about to reroll the system\'s seed.';
+let getResetStageMessage = () => 'You are about to reroll the system\'s seed.';
 
-var resetStage = () => renderer.rerollSeed(globalSeed.nextInt());
+let resetStage = () => renderer.rerollSeed(globalSeed.nextInt());
 
-var getTertiaryEquation = () =>
+let getTertiaryEquation = () =>
 {
     if(altCurrencies)
         return renderer.getOriString();
     return renderer.getStateString();
 }
 
-var get3DGraphPoint = () => renderer.getCursor();
+let get3DGraphPoint = () => renderer.getCursor();
 
-var get3DGraphTranslation = () => renderer.getCamera();
+let get3DGraphTranslation = () => renderer.getCamera();
 
 init();

--- a/renderer.js
+++ b/renderer.js
@@ -309,7 +309,6 @@ class LSystem
         this.rotations.set('^', new Quaternion(c, 0, s, 0));
         this.rotations.set('\\', new Quaternion(c, -s, 0, 0));
         this.rotations.set('/', new Quaternion(c, s, 0, 0));
-
         /**
          * @type {number} the seed (for stochastic systems).
          * @public
@@ -322,6 +321,11 @@ class LSystem
         this.random = new LCG(this.seed);
     }
 
+    /**
+     * Derive a sequence from the input string.
+     * @param {string} state the input string.
+     * @returns {string} the derivation.
+     */
     derive(state)
     {
         let result = '';
@@ -340,12 +344,19 @@ class LSystem
         }
         return result;
     }
+    /**
+     * Sets the system's seed.
+     * @param {number} seed the seed.
+     */
     setSeed(seed)
     {
         this.seed = seed;
         this.random = new LCG(this.seed);
     }
-
+    /**
+     * Returns the system's string representation.
+     * @returns {string} the string.
+     */
     toString()
     {
         let result = `${this.axiom} ${this.turnAngle} ${this.seed} ` +
@@ -361,8 +372,32 @@ class LSystem
     }
 }
 
+/**
+ * The renderer handles all logic for drawing the L-system.
+ */
 class Renderer
 {
+    /**
+     * @constructor
+     * @param {LSystem} system the L-system to be handled.
+     * @param {number} initScale (default: 1; non-zero) the initial scale.
+     * @param {number} figureScale (default: 2; non-zero) the per-level scale.
+     * @param {boolean} cursorFocused (default: false) the camera mode.
+     * @param {number} camX (default: 0) the camera's x-axis centre.
+     * @param {number} camY (default: 0) the camera's y-axis centre.
+     * @param {number} camZ (default: 0) the camera's z-axis centre.
+     * @param {number} followFactor (default: 0.15) the camera's
+     * cursor-following speed.
+     * @param {number} loopMode (default: 0) the renderer's looping mode.
+     * @param {boolean} upright (default: false) whether to rotate the system
+     * around the z-axis by 90 degrees.
+     * @param {boolean} quickDraw (default: false) whether to skip through
+     * straight lines on the way forward.
+     * @param {boolean} quickBacktrack (default: false) whether to skip through
+     * straight lines on the way backward.
+     * @param {string} backtrackList (default: '+-&^\\/|[]') a list of symbols
+     * to act as stoppers for backtracking.
+     */
     constructor(system, initScale = 1, figureScale = 2, cursorFocused = false,
         camX = 0, camY = 0, camZ = 0, followFactor = 0.15, loopMode = 0,
         upright = false, quickDraw = false, quickBacktrack = false,
@@ -370,10 +405,15 @@ class Renderer
     {
         this.system = system;
         this.initScale = initScale;
+        if(this.initScale == 0)
+            this.initScale = 1;
         this.figureScale = figureScale;
+        if(this.figureScale == 0)
+            this.figureScale = 1;
         this.cursorFocused = cursorFocused;
         this.camera = new Vector3(camX, camY, camZ);
         this.followFactor = followFactor;
+        this.followFactor = Math.min(Math.max(this.followFactor, 0), 1);
         this.loopMode = loopMode;
         this.upright = upright;
         this.quickDraw = quickDraw;
@@ -1374,8 +1414,6 @@ var createConfigMenu = () =>
         onTextChanged: (ot, nt) =>
         {
             tmpFScale = Number(nt);
-            if(tmpFScale == 0)
-                tmpFScale = 1;
         }
     });
     let tmpCFC = renderer.cursorFocused;
@@ -1491,7 +1529,6 @@ var createConfigMenu = () =>
         onTextChanged: (ot, nt) =>
         {
             tmpFF = Number(nt);
-            tmpFF = Math.min(Math.max(tmpFF, 0), 1);
         }
     });
     let tmpOD = renderer.loopMode;

--- a/renderer.js
+++ b/renderer.js
@@ -1047,7 +1047,7 @@ Turning angle: 12°
 
 Applies static camera:
 Scale: 6, 1
-Centre: (0.7, 0, 0)
+Centre: (1, 0, 0)
 Upright`,
         system: new LSystem('A', [
             'A=I[L]B,I[L]A,I[L][R]B,IF',
@@ -1056,7 +1056,7 @@ Upright`,
             'R=+++I,++I,++++I',
             'F=[---[I+I]--I+I][+++[I-I]++I-I]I'
         ], 12),
-        config: [6, 1, 0.7, 0, 0, true]
+        config: [6, 1, 1, 0, 0, true]
     },
     {
         title: 'Example: Blackboard tree (3D)',
@@ -1240,6 +1240,13 @@ var init = () =>
         ts.canBeRefunded = (_) => true;
         ts.boughtOrRefunded = (_) => time = 0;
     }
+
+    theory.createSecretAchievement(0, undefined,
+        'Watching Grass Grow',
+        'Let the renderer draw a 5-minute long figure or playlist.',
+        'Be patient.',
+        () => min.value > 4.6
+    );
 }
 
 var alwaysShowRefundButtons = () => true;
@@ -1259,10 +1266,6 @@ var tick = (elapsedTime, multiplier) =>
 {
     if(ts.level == 0)
         return;
-
-    renderer.tick(elapsedTime);
-    let msTime = renderer.getElapsedTime();
-    min.value = msTime[0] + msTime[1] / 100;
 
     if(timeCheck(elapsedTime))
     {
@@ -1300,6 +1303,10 @@ var tick = (elapsedTime, multiplier) =>
         else
             time -= 1 / ts.level;
     }
+    
+    renderer.tick(elapsedTime);
+    let msTime = renderer.getElapsedTime();
+    min.value = msTime[0] + msTime[1] / 100;
 }
 
 var getEquationOverlay = () =>

--- a/renderer.js
+++ b/renderer.js
@@ -39,7 +39,7 @@ var description = 'An educational tool that lets you draw various fractal ' +
                   'changes to the internal state.';
 var authors = 'propfeds#5988\n\nThanks to:\nSir Gilles-Philippe Paillé, for ' +
               'providing help with quaternions';
-var versionStr = 'v0.18.2';
+var versionStr = 'v0.19 WIP';
 var version = 0.182;
 var time = 0;
 var page = 0;
@@ -1322,7 +1322,7 @@ var createConfigMenu = () =>
                                 [
                                     ui.createLatexLabel
                                     ({
-                                        text: 'Looping: ',
+                                        text: 'Loop mode: ',
                                         row: 0,
                                         column: 0,
                                         verticalOptions: LayoutOptions.CENTER
@@ -1824,7 +1824,7 @@ var createViewMenu = (title) =>
                     [
                         ui.createButton
                         ({
-                            text: 'Apply',
+                            text: 'Construct',
                             row: 0,
                             column: 0,
                             onClicked: () =>
@@ -2001,6 +2001,7 @@ var createManualMenu = () =>
 {
     let pageTitle = ui.createLatexLabel
     ({
+        // padding: new Thickness(0, 0),
         text: manualPages[page].title,
         horizontalOptions: LayoutOptions.CENTER,
         verticalOptions: LayoutOptions.CENTER
@@ -2064,7 +2065,7 @@ var createManualMenu = () =>
                         }),
                         ui.createButton
                         ({
-                            text: 'Apply',
+                            text: 'Construct',
                             row: 0,
                             column: 1,
                             isVisible: () => 'system' in manualPages[page],

--- a/renderer.js
+++ b/renderer.js
@@ -1,12 +1,12 @@
 import { FreeCost } from '../api/Costs';
 import { theory } from '../api/Theory';
-import { ui } from '../api/ui/UI';
 import { Utils } from '../api/Utils';
 import { Vector3 } from '../api/Vector3';
+import { ui } from '../api/ui/UI';
+import { Color } from '../api/ui/properties/Color';
 import { LayoutOptions } from '../api/ui/properties/LayoutOptions';
 import { TextAlignment } from '../api/ui/properties/TextAlignment';
 import { Thickness } from '../api/ui/properties/Thickness';
-import { Color } from '../api/ui/properties/Color';
 import { TouchType } from '../api/ui/properties/TouchType';
 
 /*
@@ -22,8 +22,8 @@ camera rotation slander in the world. In this theory, the vector is initially
 heading in the X-axis, unlike the Y-axis which is way more common in common
 implementations of any kind. I'm just a unit circle kind of person.
 
-If the X is half of a laughing face, then the Y represents my waifu Ms. Y, and
-the Z stands for Zombies.
+If the X is the eyes of a laughing face, then the Y represents my waifu Ms. Y,
+and the Z stands for Zombies.
 
 (c) 2022 Temple of Pan (R) (TM) All rights reversed.
 */
@@ -123,7 +123,7 @@ class LCG
     }
     /**
      * Returns a random element from an array.
-     * @param {array} array the array.
+     * @param {any[]} array the array.
      * @returns the element.
      */
     choice(array)
@@ -133,7 +133,7 @@ class LCG
 }
 
 /**
- * Represents a quaternion.
+ * Represents one hell of a quaternion.
  */
 class Quaternion
 {
@@ -231,12 +231,34 @@ class Quaternion
     }
 }
 
+/**
+ * Represents an L-system.
+ */
 class LSystem
 {
+    /**
+     * @constructor
+     * @param {string} axiom the starting sequence.
+     * @param {string[]} rules the production rules.
+     * @param {number} turnAngle (default: 30) the turning angle (in degrees).
+     * @param {number} seed (default: 0) the seed (for stochastic systems).
+     */
     constructor(axiom, rules, turnAngle = 30, seed = 0)
     {
+        /**
+         * @type {string} the starting sequence.
+         * @public
+         */
         this.axiom = axiom;
+        /**
+         * @type {string[]} the production rules.
+         * @public
+         */
         this.rules = new Map();
+        /**
+         * @type {string} a list of symbols ignored by the renderer.
+         * @public
+         */
         this.ignoreList = '';
         for(let i = 0; i < rules.length; ++i)
         {
@@ -263,10 +285,23 @@ class LSystem
                 }
             }
         }
+        /**
+         * @type {number} the turning angle (in degrees).
+         * @public
+         */
         this.turnAngle = turnAngle;
+        /**
+         * @type {number} half the turning angle (in radians).
+         * @public
+         */
         this.halfAngle = this.turnAngle * Math.PI / 360;
         let s = Math.sin(this.halfAngle);
         let c = Math.cos(this.halfAngle);
+        /**
+         * @type {Map<string, Quaternion>} a map of rotation quaternions for
+         * quicker calculations.
+         * @public but shouldn't be.
+         */
         this.rotations = new Map();
         this.rotations.set('+', new Quaternion(c, 0, 0, -s));
         this.rotations.set('-', new Quaternion(c, 0, 0, s));
@@ -275,7 +310,15 @@ class LSystem
         this.rotations.set('\\', new Quaternion(c, -s, 0, 0));
         this.rotations.set('/', new Quaternion(c, s, 0, 0));
 
+        /**
+         * @type {number} the seed (for stochastic systems).
+         * @public
+         */
         this.seed = seed;
+        /**
+         * @type {LCG} the LCG used for random number generation.
+         * @public not sure, ask Itsuki.
+         */
         this.random = new LCG(this.seed);
     }
 

--- a/renderer.js
+++ b/renderer.js
@@ -836,8 +836,10 @@ class Renderer
     getProgressString()
     {
         return `i=${Math.max(this.idx - 1, 0)}/` +
-        `${this.levels[this.lvl].length - 2}&` +
-        `(${getCoordString(this.getProgressPercent())}\\%)`;
+        `${this.levels[this.lvl].length - 2}`;
+        // return `i=${Math.max(this.idx - 1, 0)}/` +
+        // `${this.levels[this.lvl].length - 2}&` +
+        // `(${getCoordString(this.getProgressPercent())}\\%)`;
     }
     /**
      * Returns the cursor's position as a string.

--- a/renderer.js
+++ b/renderer.js
@@ -8,6 +8,7 @@ import { LayoutOptions } from '../api/ui/properties/LayoutOptions';
 import { TextAlignment } from '../api/ui/properties/TextAlignment';
 import { Thickness } from '../api/ui/properties/Thickness';
 import { TouchType } from '../api/ui/properties/TouchType';
+import { ImageSource } from '../api/ui/properties/ImageSource';
 
 /*
 Disclaimer: The consensus around L-system's grammar is generally not much
@@ -1342,7 +1343,7 @@ var createVariableButton = (variable, height) =>
     return frame;
 }
 
-var createMinusButton = (variable, height) =>
+var createMinusButton = (variable, height, symbol = '-') =>
 {
     let bc = () => variable.level > 0 ?
     Color.MINIGAME_TILE_BORDER : Color.TRANSPARENT;
@@ -1354,7 +1355,7 @@ var createMinusButton = (variable, height) =>
         verticalOptions: LayoutOptions.CENTER,
         content: ui.createLatexLabel
         ({
-            text: '-',
+            text: symbol,
             horizontalOptions: LayoutOptions.CENTER,
             verticalOptions: LayoutOptions.CENTER,
             textColor: () => variable.level > 0 ? Color.TEXT : Color.TEXT_MEDIUM
@@ -1387,7 +1388,7 @@ var createMinusButton = (variable, height) =>
     return frame;
 }
 
-var createPlusButton = (variable, height, quickbuyAmount = 10) =>
+var createPlusButton = (variable, height, symbol = '+', quickbuyAmount = 10) =>
 {
     let bc = () => variable.level < variable.maxLevel ?
     Color.MINIGAME_TILE_BORDER : Color.TRANSPARENT;
@@ -1399,7 +1400,7 @@ var createPlusButton = (variable, height, quickbuyAmount = 10) =>
         verticalOptions: LayoutOptions.CENTER,
         content: ui.createLatexLabel
         ({
-            text: '+',
+            text: symbol,
             horizontalOptions: LayoutOptions.CENTER,
             verticalOptions: LayoutOptions.CENTER,
             textColor: () => variable.level < variable.maxLevel ?
@@ -1570,7 +1571,7 @@ var getUpgradeListDelegate = () =>
                             columnDefinitions: ['50*', '50*'],
                             children:
                             [
-                                createMinusButton(l, height),
+                                createMinusButton(l, height, '–'),
                                 createPlusButton(l, height)
                             ]
                         }),
@@ -1583,7 +1584,7 @@ var getUpgradeListDelegate = () =>
                             columnDefinitions: ['50*', '50*'],
                             children:
                             [
-                                createMinusButton(ts, height),
+                                createMinusButton(ts, height, '–'),
                                 createPlusButton(ts, height)
                             ]
                         })
@@ -1775,6 +1776,7 @@ var createConfigMenu = () =>
         value: tmpLM,
         // minimumTrackColor: Color.MINIGAME_TILE_BORDER,
         // maximumTrackColor: Color.BORDER,
+        // thumbImageSource: ImageSource.UPGRADES,
         onValueChanged: () =>
         {
             tmpLM = Math.round(LMSlider.value);

--- a/renderer.js
+++ b/renderer.js
@@ -44,7 +44,7 @@ var versionStr = 'v0.19 WIP';
 var version = 0.182;
 var time = 0;
 var page = 0;
-var offlineDrawing = true;
+var offlineDrawing = false;
 var gameIsOffline = false;
 var altCurrencies = true;
 var tickDelayMode = true;
@@ -715,7 +715,7 @@ class Renderer
      */
     tick(dt)
     {
-        if(this.loopMode == 0 && this.stack.length == 1)
+        if(this.loopMode == 0 && this.idx >= this.levels[this.lvl].length)
             return;
         
         if(this.lvl > this.loaded + 1)
@@ -744,6 +744,21 @@ class Renderer
 
         if(this.elapsed == 0)
             return;
+
+        if(this.idx >= this.levels[this.lvl].length)
+        {
+            switch(this.loopMode)
+            {
+                case 2:
+                    l.buy(1);
+                    break;
+                case 1:
+                    this.reset(false);
+                    break;
+                case 0:
+                    return;
+            }
+        }
 
         let i;
         for(i = this.idx; i < this.levels[this.lvl].length; ++i)
@@ -778,36 +793,23 @@ class Renderer
                 case ']':
                     if(this.stack.length == 0)
                         return;
-                    if(this.loopMode == 0 && this.stack.length == 1)
-                    {
-                        this.idx = i;
-                        return;
-                    }
+
                     let t = this.stack.pop();
                     this.state = t[0];
                     this.ori = t[1];
                     if(this.stack.length ==
-                        this.idStack[this.idStack.length - 1])
+                    this.idStack[this.idStack.length - 1])
                     {
                         this.idStack.pop();
                         this.idx = i + 1;
-                        if(this.idx >= this.levels[this.lvl].length)
-                        {
-                            this.idx = 0;
-                            if(this.loopMode == 2)
-                                l.buy(1);
-                            else
-                                this.elapsed = 0;
-                            this.reverse = false;
-                        }
                     }
                     return;
                 default:
                     if(this.system.ignoreList.includes(
-                        this.levels[this.lvl][i]))
+                    this.levels[this.lvl][i]))
                         break;
                     let breakAhead = this.backtrackList.includes(
-                        this.levels[this.lvl][i + 1]);
+                    this.levels[this.lvl][i + 1]);
                     if(!this.quickBacktrack || breakAhead)
                         this.stack.push([this.state, this.ori]);
                     this.forward();
@@ -883,7 +885,9 @@ class Renderer
      */
     getProgressFrac()
     {
-        return [Math.max(this.idx - 1, 0), (this.levels[this.lvl].length - 2)];
+        return [Math.max(Math.min(this.idx - 1,
+        this.levels[this.lvl].length - 2), 0),
+        (this.levels[this.lvl].length - 2)];
     }
     /**
      * Returns the current progress on this level.
@@ -894,8 +898,8 @@ class Renderer
         if(typeof this.levels[this.lvl] == 'undefined')
             return 0;
 
-        return Math.max(this.idx - 1, 0) * 100 /
-        (this.levels[this.lvl].length - 2);
+        let pf = this.getProgressFrac();
+        return pf[0] * 100 / pf[1];
     }
     /**
      * Returns the current progress as a string.
@@ -903,7 +907,8 @@ class Renderer
      */
     getProgressString()
     {
-        return `i=${Math.max(this.idx - 1, 0)}/${this.levels[this.lvl].length - 2}`;
+        let pf = this.getProgressFrac();
+        return `i=${pf[0]}/${pf[1]}`;
     }
     /**
      * Returns a loading message.
@@ -1315,9 +1320,9 @@ var init = () =>
 
     theory.createSecretAchievement(0, undefined,
         'Watching Grass Grow',
-        'Let the renderer draw a 5-minute long figure or playlist.',
+        'Let the renderer draw a 10-minute long figure or playlist.',
         'Be patient.',
-        () => min.value > 4.6
+        () => min.value > 9.6
     );
 }
 

--- a/renderer.js
+++ b/renderer.js
@@ -502,7 +502,7 @@ class Renderer
          */
         this.idx = 0;
         /**
-         * @type {number} the elapsed time of a system.
+         * @type {number} the elapsed time.
          * @public
          */
         this.elapsed = 0;
@@ -728,10 +728,11 @@ class Renderer
                         this.idx = i + 1;
                         if(this.idx >= this.levels[this.lvl].length)
                         {
-                            this.elapsed = 0;
                             this.idx = 0;
                             if(this.loopMode == 2)
                                 l.buy(1);
+                            else
+                                this.elapsed = 0;
                             this.reverse = false;
                         }
                     }
@@ -1206,8 +1207,8 @@ var init = () =>
     //     pitch = theory.createCurrency('j');
     //     yaw = theory.createCurrency('k');
     // }
-    min = theory.createCurrency(' out of');
-    sec = theory.createCurrency(' chars');
+    min = theory.createCurrency(' (elapsed)');
+    // sec = theory.createCurrency(' chars');
     progress = theory.createCurrency('%');
 
     // l (Level)
@@ -1260,9 +1261,8 @@ var tick = (elapsedTime, multiplier) =>
         return;
 
     renderer.tick(elapsedTime);
-    let progFrac = renderer.getProgressFrac();
-    min.value = progFrac[0];
-    sec.value = progFrac[1];
+    let msTime = renderer.getElapsedTime();
+    min.value = msTime[0] + msTime[1] / 100;
 
     if(timeCheck(elapsedTime))
     {

--- a/renderer.js
+++ b/renderer.js
@@ -2920,35 +2920,42 @@ var setInternalState = (stateStr) =>
     if(worldValues.length > 5)
         tickDelayMode = Boolean(Number(worldValues[5]));
 
-    let systemValues = values[2].split(' ');
-    let system = new LSystem(systemValues[0], systemValues.slice(3),
-    Number(systemValues[1]), Number(systemValues[2]));
+    if(values.length > 1)
+    {
+        let rendererValues = values[1].split(' ');
+        if(rendererValues.length > 0)
+            rendererValues[0] = Number(rendererValues[0]);
+        if(rendererValues.length > 1)
+            rendererValues[1] = Number(rendererValues[1]);
+        if(rendererValues.length > 2)
+            rendererValues[2] = Boolean(Number(rendererValues[2]));
+        if(rendererValues.length > 3)
+            rendererValues[3] = Number(rendererValues[3]);
+        if(rendererValues.length > 4)
+            rendererValues[4] = Number(rendererValues[4]);
+        if(rendererValues.length > 5)
+            rendererValues[5] = Number(rendererValues[5]);
+        if(rendererValues.length > 6)
+            rendererValues[6] = Number(rendererValues[6]);
+        if(rendererValues.length > 7)
+            rendererValues[7] = Number(rendererValues[7]);
+        if(rendererValues.length > 8)
+            rendererValues[8] = Boolean(Number(rendererValues[8]));
+        if(rendererValues.length > 9)
+            rendererValues[9] = Boolean(Number(rendererValues[9]));
+        if(rendererValues.length > 10)
+            rendererValues[10] = Boolean(Number(rendererValues[10]));
 
-    let rendererValues = values[1].split(' ');
-    if(rendererValues.length > 0)
-        rendererValues[0] = Number(rendererValues[0]);
-    if(rendererValues.length > 1)
-        rendererValues[1] = Number(rendererValues[1]);
-    if(rendererValues.length > 2)
-        rendererValues[2] = Boolean(Number(rendererValues[2]));
-    if(rendererValues.length > 3)
-        rendererValues[3] = Number(rendererValues[3]);
-    if(rendererValues.length > 4)
-        rendererValues[4] = Number(rendererValues[4]);
-    if(rendererValues.length > 5)
-        rendererValues[5] = Number(rendererValues[5]);
-    if(rendererValues.length > 6)
-        rendererValues[6] = Number(rendererValues[6]);
-    if(rendererValues.length > 7)
-        rendererValues[7] = Number(rendererValues[7]);
-    if(rendererValues.length > 8)
-        rendererValues[8] = Boolean(Number(rendererValues[8]));
-    if(rendererValues.length > 9)
-        rendererValues[9] = Boolean(Number(rendererValues[9]));
-    if(rendererValues.length > 10)
-        rendererValues[10] = Boolean(Number(rendererValues[10]));
-
-    renderer = new Renderer(system, ...rendererValues);
+        if(values.length > 2)
+        {
+            let systemValues = values[2].split(' ');
+            let system = new LSystem(systemValues[0], systemValues.slice(3),
+            Number(systemValues[1]), Number(systemValues[2]));
+            renderer = new Renderer(system, ...rendererValues);
+        }
+        else
+            renderer = new Renderer(arrow, ...rendererValues);
+    }
     
     for(let i = 3; i + 1 < values.length; i += 2)
         savedSystems.set(values[i], values[i + 1]);

--- a/renderer.js
+++ b/renderer.js
@@ -717,8 +717,11 @@ class Renderer
     {
         if(this.loopMode == 0 && this.stack.length == 1)
             return;
-        else
-            this.elapsed += dt;
+        
+        if(this.lvl > this.loaded + 1)
+            return;
+
+        this.elapsed += dt;
     }
     /**
      * Computes the next cursor position internally.

--- a/renderer.js
+++ b/renderer.js
@@ -527,33 +527,33 @@ class Quaternion
 {
     /**
      * @constructor
-     * @param {number} w (default: 1) the real component.
-     * @param {number} x (default: 0) the imaginary i component.
-     * @param {number} y (default: 0) the imaginary j component.
-     * @param {number} z (default: 0) the imaginary k component.
+     * @param {number} r (default: 1) the real component.
+     * @param {number} i (default: 0) the imaginary i component.
+     * @param {number} j (default: 0) the imaginary j component.
+     * @param {number} k (default: 0) the imaginary k component.
      */
-    constructor(w = 1, x = 0, y = 0, z = 0)
+    constructor(r = 1, i = 0, j = 0, k = 0)
     {
         /**
          * @type {number} the real component.
          * @public
          */
-        this.w = w;
+        this.r = r;
         /**
          * @type {number} the imaginary i component.
          * @public
          */
-        this.x = x;
+        this.i = i;
         /**
          * @type {number} the imaginary j component.
          * @public
          */
-        this.y = y;
+        this.j = j;
         /**
          * @type {number} the imaginary k component.
          * @public
          */
-        this.z = z;
+        this.k = k;
     }
 
     /**
@@ -565,10 +565,10 @@ class Quaternion
     add(quat)
     {
         return new Quaternion(
-            this.w + quat.w,
-            this.x + quat.x,
-            this.y + quat.y,
-            this.z + quat.z
+            this.r + quat.r,
+            this.i + quat.i,
+            this.j + quat.j,
+            this.k + quat.k
         );
     }
     /**
@@ -579,14 +579,14 @@ class Quaternion
      */
     mul(quat)
     {
-        let t0 = this.w * quat.w - this.x * quat.x -
-        this.y * quat.y - this.z * quat.z;
-        let t1 = this.w * quat.x + this.x * quat.w +
-        this.y * quat.z - this.z * quat.y;
-        let t2 = this.w * quat.y - this.x * quat.z +
-        this.y * quat.w + this.z * quat.x;
-        let t3 = this.w * quat.z + this.x * quat.y -
-        this.y * quat.x + this.z * quat.w;
+        let t0 = this.r * quat.r - this.i * quat.i -
+        this.j * quat.j - this.k * quat.k;
+        let t1 = this.r * quat.i + this.i * quat.r +
+        this.j * quat.k - this.k * quat.j;
+        let t2 = this.r * quat.j - this.i * quat.k +
+        this.j * quat.r + this.k * quat.i;
+        let t3 = this.r * quat.k + this.i * quat.j -
+        this.j * quat.i + this.k * quat.r;
         return new Quaternion(t0, t1, t2, t3);
     }
     /**
@@ -597,7 +597,7 @@ class Quaternion
      */
     neg()
     {
-        return new Quaternion(this.w, -this.x, -this.y, -this.z);
+        return new Quaternion(this.r, -this.i, -this.j, -this.k);
     }
     /**
      * Returns a rotation vector from the quaternion.
@@ -606,7 +606,7 @@ class Quaternion
     getRotVector()
     {
         let r = this.neg().mul(xAxisQuat).mul(this);
-        return new Vector3(r.x, r.y, r.z);
+        return new Vector3(r.i, r.j, r.k);
     }
     /**
      * Returns the quaternion's string representation.
@@ -614,7 +614,7 @@ class Quaternion
      */
     toString()
     {
-        return `${getCoordString(this.w)} + ${getCoordString(this.x)}i + ${getCoordString(this.y)}j + ${getCoordString(this.z)}k`;
+        return `${getCoordString(this.r)} + ${getCoordString(this.i)}i + ${getCoordString(this.j)}j + ${getCoordString(this.k)}k`;
     }
 }
 
@@ -3078,6 +3078,7 @@ let createWorldMenu = () =>
                 ui.createGrid
                 ({
                     columnDefinitions: ['70*', '30*'],
+                    rowDefinitions: [40, 40, 40],
                     children:
                     [
                         ui.createLatexLabel

--- a/renderer.js
+++ b/renderer.js
@@ -1533,7 +1533,7 @@ var getEquationOverlay = () =>
     let result = ui.createLatexLabel
     ({
         text: getLoc('equationOverlay'),
-        displacementX: 6,
+        displacementX: 5,
         displacementY: 4,
         fontSize: 9,
         textColor: Color.TEXT_MEDIUM

--- a/renderer.js
+++ b/renderer.js
@@ -1350,22 +1350,6 @@ var createConfigMenu = () =>
             ODSlider.value = tmpOD;
         }
     });
-    // let ODSwitch = ui.createSwitch
-    // ({
-    //     isToggled: Boolean(tmpOD),
-    //     row: 0,
-    //     column: 1,
-    //     horizontalOptions: LayoutOptions.END,
-    //     onTouched: (e) =>
-    //     {
-    //         if(e.type == TouchType.SHORTPRESS_RELEASED || e.type == TouchType.LONGPRESS_RELEASED)
-    //         {
-    //             Sound.playClick();
-    //             tmpOD = !tmpOD;
-    //             ODSwitch.isToggled = tmpOD;
-    //         }
-    //     }
-    // });
     let tmpUpright = renderer.upright;
     let uprightSwitch = ui.createSwitch
     ({
@@ -1375,7 +1359,8 @@ var createConfigMenu = () =>
         horizontalOptions: LayoutOptions.END,
         onTouched: (e) =>
         {
-            if(e.type == TouchType.SHORTPRESS_RELEASED || e.type == TouchType.LONGPRESS_RELEASED)
+            if(e.type == TouchType.SHORTPRESS_RELEASED ||
+                e.type == TouchType.LONGPRESS_RELEASED)
             {
                 Sound.playClick();
                 tmpUpright = !tmpUpright;
@@ -1392,7 +1377,8 @@ var createConfigMenu = () =>
         horizontalOptions: LayoutOptions.END,
         onTouched: (e) =>
         {
-            if(e.type == TouchType.SHORTPRESS_RELEASED || e.type == TouchType.LONGPRESS_RELEASED)
+            if(e.type == TouchType.SHORTPRESS_RELEASED ||
+                e.type == TouchType.LONGPRESS_RELEASED)
             {
                 Sound.playClick();
                 tmpQD = !tmpQD;
@@ -1409,7 +1395,8 @@ var createConfigMenu = () =>
         horizontalOptions: LayoutOptions.END,
         onTouched: (e) =>
         {
-            if(e.type == TouchType.SHORTPRESS_RELEASED || e.type == TouchType.LONGPRESS_RELEASED)
+            if(e.type == TouchType.SHORTPRESS_RELEASED ||
+                e.type == TouchType.LONGPRESS_RELEASED)
             {
                 Sound.playClick();
                 tmpQB = !tmpQB;
@@ -1540,7 +1527,9 @@ var createConfigMenu = () =>
                             onClicked: () =>
                             {
                                 Sound.playClick();
-                                renderer.configure(tmpIScale, tmpFScale, tmpCFC, tmpCX, tmpCY, tmpCZ, tmpFF, tmpOD, tmpUpright, tmpQD, tmpQB, tmpEXB);
+                                renderer.configure(tmpIScale, tmpFScale,
+                                    tmpCFC, tmpCX, tmpCY, tmpCZ, tmpFF, tmpOD,
+                                    tmpUpright, tmpQD, tmpQB, tmpEXB);
                                 menu.hide();
                             }
                         }),
@@ -1748,7 +1737,8 @@ var createSystemMenu = () =>
                     onClicked: () =>
                     {
                         Sound.playClick();
-                        renderer.applySystem(new LSystem(tmpAxiom, tmpRules, tmpAngle, tmpSeed));
+                        renderer.applySystem(new LSystem(tmpAxiom, tmpRules,
+                            tmpAngle, tmpSeed));
                         menu.hide();
                     }
                 })
@@ -1791,18 +1781,11 @@ var createNamingMenu = (title, values) =>
                         while(savedSystems.has(tmpName))
                             tmpName += ' (copy)';
                         savedSystems.set(tmpName, values);
-                        // let saveMenu = createSaveMenu();
-                        // saveMenu.show();
                         menu.hide();
                     }
                 })
             ]
-        }),
-        // onDisappearing: () =>
-        // {
-        //     let saveMenu = createSaveMenu();
-        //     saveMenu.show();
-        // }
+        })
     });
     return menu;
 }
@@ -1838,7 +1821,9 @@ var createClipboardMenu = (values) =>
                     {
                         Sound.playClick();
                         let systemValues = tmpSys.split(' ');
-                        renderer.applySystem(new LSystem(systemValues[0], systemValues.slice(3), Number(systemValues[1]), Number(systemValues[2])));
+                        renderer.applySystem(new LSystem(systemValues[0],
+                            systemValues.slice(3), Number(systemValues[1]),
+                            Number(systemValues[2])));
                         menu.hide();
                     }
                 })
@@ -1923,7 +1908,8 @@ var createViewMenu = (title) =>
                                         text: tmpAngle.toString(),
                                         row: 0,
                                         column: 3,
-                                        horizontalTextAlignment: TextAlignment.END
+                                        horizontalTextAlignment:
+                                        TextAlignment.END
                                     }),
                                 ]
                             }),
@@ -1967,7 +1953,8 @@ var createViewMenu = (title) =>
                                         text: tmpSeed.toString(),
                                         row: 1,
                                         column: 1,
-                                        horizontalTextAlignment: TextAlignment.END
+                                        horizontalTextAlignment:
+                                        TextAlignment.END
                                     })
                                 ]
                             })
@@ -1993,7 +1980,8 @@ var createViewMenu = (title) =>
                             onClicked: () =>
                             {
                                 Sound.playClick();
-                                renderer.applySystem(new LSystem(tmpAxiom, tmpRules, tmpAngle, tmpSeed));
+                                renderer.applySystem(new LSystem(tmpAxiom,
+                                    tmpRules, tmpAngle, tmpSeed));
                                 menu.hide();
                             }
                         }),
@@ -2013,12 +2001,6 @@ var createViewMenu = (title) =>
                 })
             ]
         })
-        
-        // onDisappearing: () =>
-        // {
-        //     let saveMenu = createSaveMenu();
-        //     saveMenu.show();
-        // }
     })
     return menu;
 }
@@ -2100,7 +2082,8 @@ var createSaveMenu = () =>
                             column: 1,
                             onClicked: () =>
                             {
-                                let clipMenu = createClipboardMenu(renderer.system.toString());
+                                let clipMenu = createClipboardMenu(
+                                    renderer.system.toString());
                                 clipMenu.show();
                             }
                         }),
@@ -2113,7 +2096,9 @@ var createSaveMenu = () =>
                             onClicked: () =>
                             {
                                 Sound.playClick();
-                                let namingMenu = createNamingMenu('Untitled L-system', renderer.system.toString(), systemGrid);
+                                let namingMenu = createNamingMenu(
+                                    'Untitled L-system',
+                                    renderer.system.toString(), systemGrid);
                                 namingMenu.onDisappearing = () =>
                                 {
                                     systemGrid.children = getSystemGrid();
@@ -2140,20 +2125,6 @@ var createSaveMenu = () =>
                     // heightRequest: ui.screenHeight * 0.25,
                     content: systemGrid
                 })
-                // ui.createBox
-                // ({
-                //     heightRequest: 1,
-                //     margin: new Thickness(0, 6)
-                // }),
-                // ui.createButton
-                // ({
-                //     text: 'Close',
-                //     onClicked: () =>
-                //     {
-                //         Sound.playClick();
-                //         menu.hide();
-                //     }
-                // })
             ]
         })
     })
@@ -2184,11 +2155,6 @@ var createManualMenu = () =>
             children:
             [
                 pageTitle,
-                // ui.createBox
-                // ({
-                //     heightRequest: 1,
-                //     margin: new Thickness(0, 6)
-                // }),
                 ui.createFrame
                 ({
                     padding: new Thickness(6, 6),
@@ -2220,9 +2186,11 @@ var createManualMenu = () =>
                                 {
                                     Sound.playClick();
                                     --page;
-                                    menu.title = `Manual (${page + 1}/${manualPages.length})`;
+                                    menu.title = `Manual (${page + 1}/
+                                    ${manualPages.length})`;
                                     pageTitle.text = manualPages[page].title;
-                                    pageContents.text = manualPages[page].contents;
+                                    pageContents.text =
+                                    manualPages[page].contents;
                                 }
                             }
                         }),
@@ -2239,7 +2207,7 @@ var createManualMenu = () =>
                                 if('config' in manualPages[page])
                                 {
                                     let a = manualPages[page].config;
-                                    renderer.configureStaticCamera(a[0], a[1], a[2], a[3], a[4], a[5]);
+                                    renderer.configureStaticCamera(...a);
                                 }
                                 menu.hide();
                             }
@@ -2256,9 +2224,11 @@ var createManualMenu = () =>
                                 if(page < manualPages.length - 1)
                                 {
                                     ++page;
-                                    menu.title = `Manual (${page + 1}/${manualPages.length})`;
+                                    menu.title = `Manual (${page + 1}/
+                                    ${manualPages.length})`;
                                     pageTitle.text = manualPages[page].title;
-                                    pageContents.text = manualPages[page].contents;
+                                    pageContents.text =
+                                    manualPages[page].contents;
                                 }
                             }
                         })
@@ -2329,7 +2299,8 @@ var createSequenceMenu = () =>
 
 var getInternalState = () =>
 {
-    let result = `${version} ${time} ${page} ${offlineDrawing ? 1 : 0} ${altCurrencies ? 1 : 0} ${tickDelayMode ? 1 : 0}`;
+    let result = `${version} ${time} ${page} ${offlineDrawing ? 1 : 0} 
+    ${altCurrencies ? 1 : 0} ${tickDelayMode ? 1 : 0}`;
     result += `\n${renderer.toString()}\n${renderer.system.toString()}`;
     for(let [key, value] of savedSystems)
     {
@@ -2354,7 +2325,8 @@ var setInternalState = (stateStr) =>
         tickDelayMode = Boolean(Number(worldValues[5]));
 
     let systemValues = values[2].split(' ');
-    let system = new LSystem(systemValues[0], systemValues.slice(3), Number(systemValues[1]), Number(systemValues[2]));
+    let system = new LSystem(systemValues[0], systemValues.slice(3),
+    Number(systemValues[1]), Number(systemValues[2]));
 
     let rendererValues = values[1].split(' ');
     if(rendererValues.length > 0)

--- a/renderer.js
+++ b/renderer.js
@@ -43,7 +43,7 @@ var versionStr = 'v0.18.2';
 var version = 0.182;
 var time = 0;
 var page = 0;
-// var offlineDrawing = false;
+var offlineDrawing = true;
 var gameIsOffline = false;
 var altCurrencies = true;
 var tickDelayMode = true;
@@ -318,7 +318,7 @@ class LSystem
 
 class Renderer
 {
-    constructor(system, initScale = 1, figureScale = 2, cursorFocused = false, camX = 0, camY = 0, camZ = 0, followFactor = 0.15, offlineDrawing = false, upright = false, quickDraw = false, quickBacktrack = false, backtrackList = '+-&^\\/|[]')
+    constructor(system, initScale = 1, figureScale = 2, cursorFocused = false, camX = 0, camY = 0, camZ = 0, followFactor = 0.15, loopMode = 0, upright = false, quickDraw = false, quickBacktrack = false, backtrackList = '+-&^\\/|[]')
     {
         this.system = system;
         this.initScale = initScale;
@@ -326,7 +326,7 @@ class Renderer
         this.cursorFocused = cursorFocused;
         this.camera = new Vector3(camX, camY, camZ);
         this.followFactor = followFactor;
-        this.offlineDrawing = offlineDrawing;
+        this.loopMode = loopMode;
         this.upright = upright;
         this.quickDraw = quickDraw;
         this.quickBacktrack = quickBacktrack;
@@ -379,7 +379,7 @@ class Renderer
         theory.clearGraph();
         theory.invalidateTertiaryEquation();
     }
-    configure(initScale, figureScale, cursorFocused, camX, camY, camZ, followFactor, offlineDrawing, upright, quickDraw, quickBacktrack, backtrackList)
+    configure(initScale, figureScale, cursorFocused, camX, camY, camZ, followFactor, loopMode, upright, quickDraw, quickBacktrack, backtrackList)
     {
         let requireReset = (initScale != this.initScale) || (figureScale != this.figureScale) || (upright != this.upright) || (quickDraw != this.quickDraw) || (quickBacktrack != this.quickBacktrack) || (backtrackList != this.backtrackList);
 
@@ -388,7 +388,7 @@ class Renderer
         this.cursorFocused = cursorFocused;
         this.camera = new Vector3(camX, camY, camZ);
         this.followFactor = followFactor;
-        this.offlineDrawing = offlineDrawing;
+        this.loopMode = loopMode;
         this.upright = upright;
         this.quickDraw = quickDraw;
         this.quickBacktrack = quickBacktrack;
@@ -548,7 +548,7 @@ class Renderer
     }
     toString()
     {
-        return`${this.initScale} ${this.figureScale} ${this.cursorFocused ? 1 : 0} ${this.camera.x} ${this.camera.y} ${this.camera.z} ${this.followFactor} ${this.offlineDrawing ? 1 : 0} ${this.upright ? 1 : 0} ${this.quickDraw ? 1 : 0} ${this.quickBacktrack ? 1 : 0} ${this.backtrackList}`;
+        return`${this.initScale} ${this.figureScale} ${this.cursorFocused ? 1 : 0} ${this.camera.x} ${this.camera.y} ${this.camera.z} ${this.followFactor} ${this.loopMode} ${this.upright ? 1 : 0} ${this.quickDraw ? 1 : 0} ${this.quickBacktrack ? 1 : 0} ${this.backtrackList}`;
     }
 }
 
@@ -712,12 +712,12 @@ var tick = (elapsedTime, multiplier) =>
         else if(gameIsOffline)
         {
             // Probably triggers only once when reloading
-            if(!renderer.offlineDrawing)
+            if(!offlineDrawing)
                 renderer.reset();
             gameIsOffline = false;
         }
 
-        if(!gameIsOffline || renderer.offlineDrawing)
+        if(!gameIsOffline || offlineDrawing)
         {
             renderer.draw(l.level);
             if(altCurrencies)
@@ -1181,7 +1181,7 @@ var createConfigMenu = () =>
             tmpFF = Math.min(Math.max(tmpFF, 0), 1);
         }
     });
-    let tmpOD = renderer.offlineDrawing;
+    let tmpOD = renderer.loopMode;
     let ODSwitch = ui.createSwitch
     ({
         isToggled: tmpOD,
@@ -1323,7 +1323,7 @@ var createConfigMenu = () =>
                                 [
                                     ui.createLatexLabel
                                     ({
-                                        text: 'Offline drawing: ',
+                                        text: 'Looping: ',
                                         row: 0,
                                         column: 0,
                                         verticalOptions: LayoutOptions.CENTER
@@ -2162,7 +2162,7 @@ var createSequenceMenu = () =>
 
 var getInternalState = () =>
 {
-    let result = `${version} ${time} ${page} ${renderer.offlineDrawing ? 1 : 0} ${altCurrencies ? 1 : 0} ${tickDelayMode ? 1 : 0}`;
+    let result = `${version} ${time} ${page} ${offlineDrawing ? 1 : 0} ${altCurrencies ? 1 : 0} ${tickDelayMode ? 1 : 0}`;
     result += `\n${renderer.toString()}\n${renderer.system.toString()}`;
     for(let [key, value] of savedSystems)
     {
@@ -2205,7 +2205,7 @@ var setInternalState = (stateStr) =>
     if(rendererValues.length > 6)
         rendererValues[6] = Number(rendererValues[6]);
     if(rendererValues.length > 7)
-        rendererValues[7] = Boolean(Number(rendererValues[7]));
+        rendererValues[7] = Number(rendererValues[7]);
     if(rendererValues.length > 8)
         rendererValues[8] = Boolean(Number(rendererValues[8]));
     if(rendererValues.length > 9)

--- a/renderer.js
+++ b/renderer.js
@@ -66,7 +66,7 @@ Warning: As of v0.18, the renderer's configuration will be messed up due to ` +
 }
 var authors =   'propfeds#5988\n\nThanks to:\nSir Gilles-Philippe Paillé, ' +
                 'for providing help with quaternions';
-var version = 0.182;
+var version = 0.19;
 
 const MAX_CHARS_PER_TICK = 10000;
 
@@ -87,7 +87,7 @@ const locStrings =
         'playlist.',
         saPatienceHint: 'Be patient.',
 
-        equationOverlay: 'v0.19: Winter Sweep (WIP)',
+        equationOverlay: 'v0.19: Winter Sweep',
 
         btnSave: 'Save',
         btnDefault: 'Reset to Defaults',
@@ -403,7 +403,7 @@ Upright`
             }
         ],
 
-        menuSequence: 'View Sequences',
+        menuSequence: 'Sequences Menu',
         labelLevelSeq: 'Level {0}: ',
 
         rerollSeed: 'You are about to reroll the system\'s seed.',

--- a/renderer.js
+++ b/renderer.js
@@ -1067,9 +1067,10 @@ var createConfigMenu = () =>
         }
     });
     let tmpCFC = renderer.cursorFocused;
+    let camModes = ['Static', 'Cursor-focused'];
     let CFCLabel = ui.createLatexLabel
     ({
-        text: `Camera mode: ${tmpCFC ? 'Cursor-focused' : 'Static'}`,
+        text: `Camera mode: ${camModes[Number(tmpCFC)]}`,
         row: 2,
         column: 0,
         verticalOptions: LayoutOptions.CENTER
@@ -1091,7 +1092,7 @@ var createConfigMenu = () =>
                 camGrid.isVisible = !tmpCFC;
                 FFLabel.isVisible = tmpCFC;
                 FFEntry.isVisible = tmpCFC;
-                CFCLabel.text = `Camera mode: ${tmpCFC ? 'Cursor-focused' : 'Static'}`;
+                CFCLabel.text = `Camera mode: ${camModes[Number(tmpCFC)]}`;
             }
         }
     });
@@ -1181,22 +1182,50 @@ var createConfigMenu = () =>
         }
     });
     let tmpOD = renderer.loopMode;
-    let ODSwitch = ui.createSwitch
+    let loopModes = ['Off', 'Level', 'Playlist'];
+    let ODLabel = ui.createLatexLabel
     ({
-        isToggled: Boolean(tmpOD),
+        text: `Loop mode: ${loopModes[tmpOD]}`,
+        row: 0,
+        column: 0,
+        verticalOptions: LayoutOptions.CENTER
+    });
+    let ODSlider = ui.createSlider
+    ({
         row: 0,
         column: 1,
-        horizontalOptions: LayoutOptions.END,
-        onTouched: (e) =>
+        minimum: 0,
+        maximum: 2,
+        value: tmpOD,
+        // minimumTrackColor: Color.MINIGAME_TILE_BORDER,
+        // maximumTrackColor: Color.BORDER,
+        onValueChanged: () =>
         {
-            if(e.type == TouchType.SHORTPRESS_RELEASED || e.type == TouchType.LONGPRESS_RELEASED)
-            {
-                Sound.playClick();
-                tmpOD = !tmpOD;
-                ODSwitch.isToggled = tmpOD;
-            }
+            tmpOD = Math.round(ODSlider.value);
+            ODLabel.text = `Loop mode: ${loopModes[tmpOD]}`;
+        },
+        onDragCompleted: () =>
+        {
+            Sound.playClick();
+            ODSlider.value = tmpOD;
         }
     });
+    // let ODSwitch = ui.createSwitch
+    // ({
+    //     isToggled: Boolean(tmpOD),
+    //     row: 0,
+    //     column: 1,
+    //     horizontalOptions: LayoutOptions.END,
+    //     onTouched: (e) =>
+    //     {
+    //         if(e.type == TouchType.SHORTPRESS_RELEASED || e.type == TouchType.LONGPRESS_RELEASED)
+    //         {
+    //             Sound.playClick();
+    //             tmpOD = !tmpOD;
+    //             ODSwitch.isToggled = tmpOD;
+    //         }
+    //     }
+    // });
     let tmpUpright = renderer.upright;
     let uprightSwitch = ui.createSwitch
     ({
@@ -1320,14 +1349,8 @@ var createConfigMenu = () =>
                                 columnDefinitions: ['70*', '30*'],
                                 children:
                                 [
-                                    ui.createLatexLabel
-                                    ({
-                                        text: 'Loop mode: ',
-                                        row: 0,
-                                        column: 0,
-                                        verticalOptions: LayoutOptions.CENTER
-                                    }),
-                                    ODSwitch,
+                                    ODLabel,
+                                    ODSlider,
                                     ui.createLatexLabel
                                     ({
                                         text: 'Upright x-axis: ',

--- a/renderer.js
+++ b/renderer.js
@@ -191,14 +191,14 @@ class Quaternion
      */
     mul(quat)
     {
-        let t0 = this.w * quat.w - this.x * quat.x
-               - this.y * quat.y - this.z * quat.z;
-        let t1 = this.w * quat.x + this.x * quat.w
-               + this.y * quat.z - this.z * quat.y;
-        let t2 = this.w * quat.y - this.x * quat.z
-               + this.y * quat.w + this.z * quat.x;
-        let t3 = this.w * quat.z + this.x * quat.y
-               - this.y * quat.x + this.z * quat.w;
+        let t0 = this.w * quat.w - this.x * quat.x -
+        this.y * quat.y - this.z * quat.z;
+        let t1 = this.w * quat.x + this.x * quat.w +
+        this.y * quat.z - this.z * quat.y;
+        let t2 = this.w * quat.y - this.x * quat.z +
+        this.y * quat.w + this.z * quat.x;
+        let t3 = this.w * quat.z + this.x * quat.y -
+        this.y * quat.x + this.z * quat.w;
         return new Quaternion(t0, t1, t2, t3);
     }
     /**
@@ -226,7 +226,8 @@ class Quaternion
      */
     toString()
     {
-        return `${getCoordString(this.w)} + ${getCoordString(this.x)}i + ${getCoordString(this.y)}j + ${getCoordString(this.z)}k`;
+        return `${getCoordString(this.w)} + ${getCoordString(this.x)}i + 
+        ${getCoordString(this.y)}j + ${getCoordString(this.z)}k`;
     }
 }
 
@@ -304,7 +305,8 @@ class LSystem
 
     toString()
     {
-        let result = `${this.axiom} ${this.turnAngle} ${this.seed} ${this.ignoreList}`;
+        let result = `${this.axiom} ${this.turnAngle} ${this.seed} 
+        ${this.ignoreList}`;
         for(let [key, value] of this.rules)
         {
             if(typeof value === 'string')
@@ -318,7 +320,10 @@ class LSystem
 
 class Renderer
 {
-    constructor(system, initScale = 1, figureScale = 2, cursorFocused = false, camX = 0, camY = 0, camZ = 0, followFactor = 0.15, loopMode = 0, upright = false, quickDraw = false, quickBacktrack = false, backtrackList = '+-&^\\/|[]')
+    constructor(system, initScale = 1, figureScale = 2, cursorFocused = false,
+        camX = 0, camY = 0, camZ = 0, followFactor = 0.15, loopMode = 0,
+        upright = false, quickDraw = false, quickBacktrack = false,
+        backtrackList = '+-&^\\/|[]')
     {
         this.system = system;
         this.initScale = initScale;
@@ -347,7 +352,7 @@ class Renderer
 
     update(level, seedChanged = false)
     {
-        let loop = this.loopMode == 2 && level > this.lvl;
+        let clearGraph = this.loopMode != 2 && level <= this.lvl;
         let start = seedChanged ? 0 : this.levels.length;
         let charCount = 0;
         for(let i = start; i <= level; ++i)
@@ -366,10 +371,9 @@ class Renderer
             }
         }
         this.lvl = level;
-        if(!loop)
-            this.reset();
+        this.reset(clearGraph);
     }
-    reset()
+    reset(clearGraph = true)
     {
         this.state = new Vector3(0, 0, 0);
         this.ori = new Quaternion();
@@ -378,12 +382,19 @@ class Renderer
         this.idStack = [];
         this.idx = 0;
         this.firstPoint = true;
-        theory.clearGraph();
+        if(clearGraph)
+            theory.clearGraph();
         theory.invalidateTertiaryEquation();
     }
-    configure(initScale, figureScale, cursorFocused, camX, camY, camZ, followFactor, loopMode, upright, quickDraw, quickBacktrack, backtrackList)
+    configure(initScale, figureScale, cursorFocused, camX, camY, camZ,
+        followFactor, loopMode, upright, quickDraw, quickBacktrack,
+        backtrackList)
     {
-        let requireReset = (initScale != this.initScale) || (figureScale != this.figureScale) || (upright != this.upright) || (quickDraw != this.quickDraw) || (quickBacktrack != this.quickBacktrack) || (backtrackList != this.backtrackList);
+        let requireReset = (initScale != this.initScale) ||
+        (figureScale != this.figureScale) || (upright != this.upright) ||
+        (quickDraw != this.quickDraw) ||
+        (quickBacktrack != this.quickBacktrack) ||
+        (backtrackList != this.backtrackList);
 
         this.initScale = initScale;
         this.figureScale = figureScale;
@@ -401,7 +412,8 @@ class Renderer
     }
     configureStaticCamera(initScale, figureScale, camX, camY, camZ, upright)
     {
-        let requireReset = (initScale != this.initScale) || (figureScale != this.figureScale) || (upright != this.upright);
+        let requireReset = (initScale != this.initScale) ||
+        (figureScale != this.figureScale) || (upright != this.upright);
 
         this.initScale = initScale;
         this.figureScale = figureScale;
@@ -480,7 +492,8 @@ class Renderer
                     let t = this.stack.pop();
                     this.state = t[0];
                     this.ori = t[1];
-                    if(this.stack.length == this.idStack[this.idStack.length - 1])
+                    if(this.stack.length ==
+                        this.idStack[this.idStack.length - 1])
                     {
                         this.idStack.pop();
                         this.idx = i + 1;
@@ -494,9 +507,11 @@ class Renderer
                     }
                     return;
                 default:
-                    if(this.system.ignoreList.includes(this.levels[this.lvl][i]))
+                    if(this.system.ignoreList.includes(
+                        this.levels[this.lvl][i]))
                         break;
-                    let breakAhead = this.backtrackList.includes(this.levels[this.lvl][i + 1]);
+                    let breakAhead = this.backtrackList.includes(
+                        this.levels[this.lvl][i + 1]);
                     if(!this.quickBacktrack || breakAhead)
                         this.stack.push([this.state, this.ori]);
                     this.forward();
@@ -518,7 +533,8 @@ class Renderer
     }
     getCursor()
     {
-        let coords = this.state / (this.initScale * this.figureScale ** this.lvl);
+        let coords = this.state / (this.initScale * this.figureScale **
+            this.lvl);
         if(this.upright)
             return new Vector3(-coords.y, -coords.x, coords.z);
         return new Vector3(coords.x, -coords.y, coords.z);
@@ -527,7 +543,8 @@ class Renderer
     {
         if(this.cursorFocused)
         {
-            let newCamera = this.getCentre() * this.followFactor + this.lastCamera * (1 - this.followFactor);
+            let newCamera = this.getCentre() * this.followFactor +
+            this.lastCamera * (1 - this.followFactor);
             this.lastCamera = newCamera;
             return newCamera;
         }
@@ -540,28 +557,40 @@ class Renderer
     }
     getProgress()
     {
-        return Math.max(this.idx - 1, 0) * 100 / (this.levels[this.lvl].length - 2);
+        return Math.max(this.idx - 1, 0) * 100 /
+        (this.levels[this.lvl].length - 2);
     }
     getProgressString()
     {
-        return `i=${Math.max(this.idx - 1, 0)}/${this.levels[this.lvl].length - 2}&(${getCoordString(this.getProgress())}\\%)`;
+        return `i=${Math.max(this.idx - 1, 0)}/
+        ${this.levels[this.lvl].length - 2}&
+        (${getCoordString(this.getProgress())}\\%)`;
     }
     getStateString()
     {
-        return `\\begin{matrix}x=${getCoordString(this.state.x)},&y=${getCoordString(this.state.y)},&z=${getCoordString(this.state.z)},&${this.getProgressString()}\\end{matrix}`;
+        return `\\begin{matrix}x=${getCoordString(this.state.x)},&y=
+        ${getCoordString(this.state.y)},&z=${getCoordString(this.state.z)},&
+        ${this.getProgressString()}\\end{matrix}`;
     }
     getOriString()
     {
-        return `\\begin{matrix}q=${this.ori.toString()},&${this.getProgressString()}\\end{matrix}`;
+        return `\\begin{matrix}q=${this.ori.toString()},&
+        ${this.getProgressString()}\\end{matrix}`;
     }
     toString()
     {
-        return`${this.initScale} ${this.figureScale} ${this.cursorFocused ? 1 : 0} ${this.camera.x} ${this.camera.y} ${this.camera.z} ${this.followFactor} ${this.loopMode} ${this.upright ? 1 : 0} ${this.quickDraw ? 1 : 0} ${this.quickBacktrack ? 1 : 0} ${this.backtrackList}`;
+        return`${this.initScale} ${this.figureScale} 
+        ${this.cursorFocused ? 1 : 0} ${this.camera.x} ${this.camera.y} 
+        ${this.camera.z} ${this.followFactor} ${this.loopMode} 
+        ${this.upright ? 1 : 0} ${this.quickDraw ? 1 : 0} 
+        ${this.quickBacktrack ? 1 : 0} ${this.backtrackList}`;
     }
 }
 
 var xAxisQuat = new Quaternion(0, 1, 0, 0);
-var getCoordString = (x) => x.toFixed(x >= -0.01 ? (x < 10 ? 3 : (x < 100 ? 2 : 1)) : (x <= -10 ? (x <= -100 ? 0 : 1) : 2));
+var getCoordString = (x) => x.toFixed(x >= -0.01 ?
+    (x < 10 ? 3 : (x < 100 ? 2 : 1)) :
+    (x <= -10 ? (x <= -100 ? 0 : 1) : 2));
 
 var arrow = new LSystem('X', ['F=FF', 'X=F[+X][-X]FX'], 30);
 var renderer = new Renderer(arrow, 1, 2, false, 1);
@@ -572,78 +601,172 @@ var manualPages =
 [
     {
         title: 'The Main Screen',
-        contents: 'The main screen consists of the renderer and its controls.\n\nLevel: the system\'s level. Pressing + or - will derive/revert the system respectively. Pressing the Level button will reveal all levels of the system.\n\nTickspeed: controls the renderer\'s drawing speed (up to 10 lines/sec, which produces less accurate lines).\nPressing the Tickspeed button will toggle between tick delay and tickspeed mode.\n(Tip: holding + or - will buy/refund a variable in bulk.)\n\nReroll: located on the top right. Pressing this button will reroll the system\'s seed (for stochastic systems).'
+        contents: `The main screen consists of the renderer and its controls.
+        \n\nLevel: the system\'s level. Pressing + or - will derive/revert the 
+        system respectively. Pressing the Level button will reveal all levels 
+        of the system.\n\nTickspeed: controls the renderer\'s drawing speed (up 
+        to 10 lines/sec, which produces less accurate lines).\nPressing the 
+        Tickspeed button will toggle between tick delay and tickspeed mode.\n
+        (Tip: holding + or - will buy/refund a variable in bulk.)\n\nReroll: 
+        located on the top right. Pressing this button will reroll the 
+        system\'s seed (for stochastic systems).`
     },
     {
         title: 'A Primer on L-systems',
-        contents: 'Developed in 1968 by biologist Aristid Lindenmayer, an L-system is a formal grammar that describes the growth of a sequence (string). It is often used to model plants and draw fractal figures.\n\nTerms:\nAxiom: the starting sequence.\nRules: how each symbol in the sequence is derived per level. Each rule is written in the form of: {symbol}={derivation(s)}\n\nSymbols:\nAny letter: moves cursor forward to draw.\n+ -: rotates cursor on the z-axis (yaw), counter-/clockwise respectively.\n& ^: rotates cursor on the y-axis (pitch).\n\\ /: rotates cursor on the x-axis (roll).\n|: reverses cursor direction.\n[ ]: allows for branches by queueing cursor positions on a stack.\n, : separates between derivations (for stochastic systems).'
+        contents: `Developed in 1968 by biologist Aristid Lindenmayer, an 
+        L-system is a formal grammar that describes the growth of a sequence 
+        (string). It is often used to model plants and draw fractal figures.
+        \n\nTerms:\nAxiom: the starting sequence.\nRules: how each symbol in 
+        the sequence is derived per level. Each rule is written in the form of: 
+        {symbol}={derivation(s)}\n\nSymbols:\nAny letter: moves cursor forward 
+        to draw.\n+ -: rotates cursor on the z-axis (yaw), counter-/clockwise 
+        respectively.\n& ^: rotates cursor on the y-axis (pitch).\n\\ /: 
+        rotates cursor on the x-axis (roll).\n|: reverses cursor direction.\n[ ]
+        : allows for branches by queueing cursor positions on a stack.\n, : 
+        separates between derivations (for stochastic systems).`
     },
     {
         title: 'Tips on Constructing an L-system',
-        contents: 'Each letter can be used to mean different things, such as drawing a flower, emulating growth stages, alternating between patterns, etc.\nTraditionally, F is used to mean forward, and X to create new branches.\n\nBrackets work in a stack mechanism, therefore every [ has to be properly followed by a ] in the same production rule.\n\nTo create a stochastic system, simply list several derivations in the same rule, separated by a , (comma). One of those derivations will be randomly selected per symbol whenever the system is derived.\nGenerally, to keep a degree of uniformity in the system, it is advised for the derivations to be similar in shape.'
+        contents: `Each letter can be used to mean different things, such as 
+        drawing a flower, emulating growth stages, alternating between 
+        patterns, etc.\nTraditionally, F is used to mean forward, and X to 
+        create new branches.\n\nBrackets work in a stack mechanism, therefore 
+        every [ has to be properly followed by a ] in the same production rule.
+        \n\nTo create a stochastic system, simply list several derivations in 
+        the same rule, separated by a , (comma). One of those derivations will 
+        be randomly selected per symbol whenever the system is derived.
+        \nGenerally, to keep a degree of uniformity in the system, it is 
+        advised for the derivations to be similar in shape.`
     },
     {
         title: 'Configuring your L-system',
-        contents: 'Configure the visual representation of your L-system with the renderer menu.\n\nInitial scale: zooms out by this much for every figure.\nFigure scale: zooms the figure out by a multiplier per level.\n\nCamera mode: toggles between static and cursor-focused.\nCentre: sets camera position for level 0 (this follows figure scale, and is based on non-upright coordinates).\nCamera follow factor: changes how quickly the camera chases the cursor.\n(Note: figure scale and camera centre needs to be experimented manually for each individual L-system.)\n\nOffline drawing: when enabled, no longer resets the graph while tabbed out.\nUpright x-axis: rotates figure by 90 degrees counter-clockwise around the z-axis.\n\nQuickdraw: skips over consecutive straight lines.\nQuick backtrack: similarly, but on the way back.\nBacktrack list: sets stopping symbols for quickdraw/backtrack.'
+        contents: `Configure the visual representation of your L-system with 
+        the renderer menu.\n\nInitial scale: zooms out by this much for every 
+        figure.\nFigure scale: zooms the figure out by a multiplier per level.
+        \n\nCamera mode: toggles between static and cursor-focused.\nCentre: 
+        sets camera position for level 0 (this follows figure scale, and is 
+        based on non-upright coordinates).\nCamera follow factor: changes how 
+        quickly the camera chases the cursor.\n(Note: figure scale and camera 
+        centre needs to be experimented manually for each individual L-system.)
+        \n\nOffline drawing: when enabled, no longer resets the graph while 
+        tabbed out.\nUpright x-axis: rotates figure by 90 degrees 
+        counter-clockwise around the z-axis.\n\nQuickdraw: skips over 
+        consecutive straight lines.\nQuick backtrack: similarly, but on the way 
+        back.\nBacktrack list: sets stopping symbols for quickdraw/backtrack.`
     },
     {
         title: 'Example: Arrow weed',
-        contents: 'Meet the default system. It tastes like mint.\n\nAxiom: X\nF=FF\nX=F[+X][-X]FX\nTurning angle: 30°\n\nScale: 1, 2\nCamera centre: (1, 0, 0)',
+        contents: `Meet the default system. It tastes like mint.\n\nAxiom: 
+        X\nF=FF\nX=F[+X][-X]FX\nTurning angle: 30°\n\nScale: 1, 2\nCamera 
+        centre: (1, 0, 0)`,
         system: arrow,
         config: [1, 2, 1, 0, 0, false]
     },
     {
         title: 'Example: Dragon curve',
-        contents: 'Also known as the Heighway dragon.\n\nAxiom: FX\nY=-FX-Y\nX=X+YF+\nTurning angle: 90°\n\nScale: 2, sqrt(2)\nCamera centre: (0, 0, 0)',
+        contents: `Also known as the Heighway dragon.\n\nAxiom: FX\nY=-FX-Y\nX=X
+        +YF+\nTurning angle: 90°\n\nScale: 2, sqrt(2)\nCamera centre: (0, 0, 0)
+        `,
         system: new LSystem('FX', ['Y=-FX-Y', 'X=X+YF+'], 90),
         config: [2, Math.sqrt(2), 0, 0, 0, false]
     },
     {
         title: 'Example: Stochastic weed',
-        contents: 'It generates a random shape every time it rolls!\n\nAxiom: F\nF=FF\nX=F-[[X]+X]+F[+FX]-X,\n     F+[[X]-X]-F[-FX]+X\nTurning angle: 22.5°\n\nScale: 1, 2\nCamera centre: (1, 0, 0)',
-        system: new LSystem('X', ['F=FF', 'X=F-[[X]+X]+F[+FX]-X,F+[[X]-X]-F[-FX]+X'], 22.5),
+        contents: `It generates a random shape every time it rolls!\n\nAxiom: 
+        F\nF=FF\nX=F-[[X]+X]+F[+FX]-X,\n     F+[[X]-X]-F[-FX]+X\nTurning angle: 
+        22.5°\n\nScale: 1, 2\nCamera centre: (1, 0, 0)`,
+        system: new LSystem('X', [
+            'F=FF',
+            'X=F-[[X]+X]+F[+FX]-X,F+[[X]-X]-F[-FX]+X'
+        ], 22.5),
         config: [1, 2, 1, 0, 0, true]
     },
     {
         title: 'Example: Lucky flower',
-        contents: 'How tall can it grow until it sprouts a flower? Reroll to find out!\n\nAxiom: A\nA=I[L]B,\n     I[L]A,\n     I[L][R]B,\n     IF\nB=I[R]A,\n     I[R]B,\n     I[L][R]A,\n     IF\nL=---I,\n     --I,\n     ----I\nR=+++I,\n     ++I,\n     ++++I\nF=[---[I+I]--I+I][+++[I-I]++I-I]I\nTurning angle: 12°',
-        system: new LSystem('A', ['A=I[L]B,I[L]A,I[L][R]B,IF', 'B=I[R]A,I[R]B,I[L][R]A,IF', 'L=---I,--I,----I', 'R=+++I,++I,++++I', 'F=[---[I+I]--I+I][+++[I-I]++I-I]I'], 12),
+        contents: `How tall can it grow until it sprouts a flower? Reroll to 
+        find out!\n\nAxiom: A\nA=I[L]B,\n     I[L]A,\n     I[L][R]B,\n     
+        IF\nB=I[R]A,\n     I[R]B,\n     I[L][R]A,\n     IF\nL=---I,\n     --I,
+        \n     ----I\nR=+++I,\n     ++I,\n     ++++I\nF=[---[I+I]--I+I][+++[I-I]
+        ++I-I]I\nTurning angle: 12°`,
+        system: new LSystem('A', [
+            'A=I[L]B,I[L]A,I[L][R]B,IF',
+            'B=I[R]A,I[R]B,I[L][R]A,IF',
+            'L=---I,--I,----I',
+            'R=+++I,++I,++++I',
+            'F=[---[I+I]--I+I][+++[I-I]++I-I]I'
+        ], 12),
         config: [3, 1.1, 0.7, 0, 0, true]
     },
     {
         title: 'Example: Blackboard tree (3D)',
-        contents: 'A blackboard tree (Alstonia scholaris) when it\'s still tiny.\n\nAxiom: F\nF=Y[++++++MF][-----NF][^^^^^OF][&&&&&PF]\nM=Z-M\nN=Z+N\nO=Z&O\nP=Z^P\nY=Z-ZY+\nZ=ZZ\nTurning angle: 8°\n\nScale: 2, 2\nCamera centre: (1.5, 0, 0)',
-        system: new LSystem('F', ['F=Y[++++++MF][-----NF][^^^^^OF][&&&&&PF]', 'M=Z-M', 'N=Z+N', 'O=Z&O', 'P=Z^P', 'Y=Z-ZY+', 'Z=ZZ'], 8),
+        contents: `A blackboard tree (Alstonia scholaris) when it\'s still tiny.
+        \n\nAxiom: F\nF=Y[++++++MF][-----NF][^^^^^OF][&&&&&PF]\nM=Z-M\nN=Z
+        +N\nO=Z&O\nP=Z^P\nY=Z-ZY+\nZ=ZZ\nTurning angle: 8°\n\nScale: 2, 
+        2\nCamera centre: (1.5, 0, 0)`,
+        system: new LSystem('F', [
+            'F=Y[++++++MF][-----NF][^^^^^OF][&&&&&PF]',
+            'M=Z-M',
+            'N=Z+N',
+            'O=Z&O',
+            'P=Z^P',
+            'Y=Z-ZY+',
+            'Z=ZZ'
+        ], 8),
         config: [2, 2, 0.6, 0, 0, true]
     },
     {
         title: 'Example: Hilbert curve (3D)',
-        contents: 'If you set to high tickspeed, it look like brainz.\n\nAxiom: X\nX=^/XF^/XFX-F^\\\\XFX&F+\\\\XFX-F\\X-\\\nTurning angle: 90°\nIgnore: X\n\nScale: 1, 2\nCamera centre: (0.5, -0.5, -0.5)',
-        system: new LSystem('X', ['X', 'X=^/XF^/XFX-F^\\\\XFX&F+\\\\XFX-F\\X-\\'], 90),
+        contents: `If you set to high tickspeed, it look like brainz.\n\nAxiom: 
+        X\nX=^/XF^/XFX-F^\\\\XFX&F+\\\\XFX-F\\X-\\\nTurning angle: 90°\nIgnore: 
+        X\n\nScale: 1, 2\nCamera centre: (0.5, -0.5, -0.5)`,
+        system: new LSystem('X', [
+            'X',
+            'X=^/XF^/XFX-F^\\\\XFX&F+\\\\XFX-F\\X-\\'
+        ], 90),
         config: [1, 2, 0.5, 0.5, 0.5, false]
     },
     {
         title: 'Example: Fern (3D)',
-        contents: 'Source: https://observablehq.com/@kelleyvanevert/3d-l-systems\n\nAxiom: FFFA\nA=[++++++++++++++FC]B^+B[--------------FD]B+BA\nC=[---------FF][+++++++++FF]B&&+C\nD=[---------FF][+++++++++FF]B&&-D\nTurning angle: 4°',
-        system: new LSystem('FFFA',['A=[++++++++++++++FC]B^+B[--------------FD]B+BA', 'C=[---------FF][+++++++++FF]B&&+C', 'D=[---------FF][+++++++++FF]B&&-D'], 4),
+        contents: `Source: https://observablehq.com/@kelleyvanevert/
+        3d-l-systems\n\nAxiom: FFFA\nA=[++++++++++++++FC]B^+B[--------------FD]B
+        +BA\nC=[---------FF][+++++++++FF]B&&+C\nD=[---------FF][+++++++++FF]B&&
+        -D\nTurning angle: 4°`,
+        system: new LSystem('FFFA', [
+            'A=[++++++++++++++FC]B^+B[--------------FD]B+BA',
+            'C=[---------FF][+++++++++FF]B&&+C',
+            'D=[---------FF][+++++++++FF]B&&-D'
+        ], 4),
         config: [3, 1.3, 0.6, 0, 0, true]
     },
     {
         title: 'Example: Cultivar FF (Botched)',
-        contents: 'Represents a common source of carbohydrates.\n\nAxiom: X\nF=FF\nX=F-[[X]+X]+F[-X]-X\nTurning angle: 15°\n\nScale: 1, 2\nCamera centre: (1, 0, 0)',
+        contents: `Represents a common source of carbohydrates.\n\nAxiom: 
+        X\nF=FF\nX=F-[[X]+X]+F[-X]-X\nTurning angle: 15°\n\nScale: 1, 2\nCamera 
+        centre: (1, 0, 0)`,
         system: new LSystem('X', ['F=FF', 'X=F-[[X]+X]+F[-X]-X'], 15),
         config: [1, 2, 1, 0, 0, true]
     },
     {
         title: 'Example: Cultivar FXF (Botched)',
-        contents: 'Commonly called the Cyclone, cultivar FXF resembles a coil of barbed wire. Legends have it, once a snake moult has weathered enough, a new life is born unto the tattered husk, and from there, it stretches.\n\nAxiom: X\nF=F[+F]XF\nX=F-[[X]+X]+F[-FX]-X\nTurning angle: 27°',
+        contents: `Commonly called the Cyclone, cultivar FXF resembles a coil 
+        of barbed wire. Legends have it, once a snake moult has weathered 
+        enough, a new life is born unto the tattered husk, and from there, it 
+        stretches.\n\nAxiom: X\nF=F[+F]XF\nX=F-[[X]+X]+F[-FX]-X\nTurning angle: 
+        27°`,
         system: new LSystem('X', ['F=F[+F]XF', 'X=F-[[X]+X]+F[-FX]-X'], 27),
         config: [1.5, 2, 0.15, -0.5, 0, false]
     },
     {
         title: 'Example: Cultivar XEXF (Botched)',
-        contents: 'Bearing the shape of a thistle, cultivar XEXF embodies the strength and resilience of nature against the harsh logarithm drop-off. It also smells really, really good.\n\nAxiom: X\nE=XEXF-\nF=FX+[E]X\nX=F-[X+[X[++E]F]]+F[X+FX]-X\nTurning angle: 22.5°',
-        system: new LSystem('X', ['E=XEXF-', 'F=FX+[E]X', 'X=F-[X+[X[++E]F]]+F[X+FX]-X'], 22.5),
+        contents: `Bearing the shape of a thistle, cultivar XEXF embodies the 
+        strength and resilience of nature against the harsh logarithm drop-off. 
+        It also smells really, really good.\n\nAxiom: X\nE=XEXF-\nF=FX+[E]
+        X\nX=F-[X+[X[++E]F]]+F[X+FX]-X\nTurning angle: 22.5°`,
+        system: new LSystem('X', [
+            'E=XEXF-',
+            'F=FX+[E]X',
+            'X=F-[X+[X[++E]F]]+F[X+FX]-X'
+        ], 22.5),
         config: [1, 3, 0.75, -0.25, 0, true]
     }
 ];
@@ -673,7 +796,8 @@ var init = () =>
         let getInfo = (level) => `\\text{Lv. }${level.toString()}`;
         l = theory.createUpgrade(0, yaw, new FreeCost);
         l.getDescription = (_) => Utils.getMath(getDesc(l.level));
-        l.getInfo = (amount) => Utils.getMathTo(getInfo(l.level), getInfo(l.level + amount));
+        l.getInfo = (amount) => Utils.getMathTo(getInfo(l.level),
+        getInfo(l.level + amount));
         l.canBeRefunded = (_) => true;
         l.boughtOrRefunded = (_) => renderer.update(l.level);
     }
@@ -682,13 +806,15 @@ var init = () =>
         let getDesc = (level) =>
         {
             if(tickDelayMode)
-                return `\\text{Tick delay: }${(level / 10).toString()}\\text{ sec}`;
+                return `\\text{Tick delay: }${(level / 10).toString()}
+                \\text{ sec}`;
             return `\\text{Tickspeed: }${level.toString()}/\\text{sec}`;
         }
         let getInfo = (level) => `\\text{Ts=}${level.toString()}/s`;
         ts = theory.createUpgrade(1, pitch, new FreeCost);
         ts.getDescription = (_) => Utils.getMath(getDesc(ts.level));
-        ts.getInfo = (amount) => Utils.getMathTo(getInfo(ts.level), getInfo(ts.level + amount));
+        ts.getInfo = (amount) => Utils.getMathTo(getInfo(ts.level),
+        getInfo(ts.level + amount));
         ts.maxLevel = 10;
         ts.canBeRefunded = (_) => true;
         ts.boughtOrRefunded = (_) => time = 0;
@@ -784,7 +910,8 @@ var createVariableButton = (variable, height) =>
 
 var createMinusButton = (variable, height) =>
 {
-    let bc = () => variable.level > 0 ? Color.MINIGAME_TILE_BORDER : Color.TRANSPARENT;
+    let bc = () => variable.level > 0 ?
+    Color.MINIGAME_TILE_BORDER : Color.TRANSPARENT;
     let frame = ui.createFrame
     ({
         column: 0,
@@ -828,7 +955,8 @@ var createMinusButton = (variable, height) =>
 
 var createPlusButton = (variable, height, quickbuyAmount = 10) =>
 {
-    let bc = () => variable.level < variable.maxLevel ? Color.MINIGAME_TILE_BORDER : Color.TRANSPARENT;
+    let bc = () => variable.level < variable.maxLevel ?
+    Color.MINIGAME_TILE_BORDER : Color.TRANSPARENT;
     let frame = ui.createFrame
     ({
         column: 1,
@@ -840,7 +968,8 @@ var createPlusButton = (variable, height, quickbuyAmount = 10) =>
             text: '+',
             horizontalOptions: LayoutOptions.CENTER,
             verticalOptions: LayoutOptions.CENTER,
-            textColor: () => variable.level < variable.maxLevel ? Color.TEXT : Color.TEXT_MEDIUM
+            textColor: () => variable.level < variable.maxLevel ?
+            Color.TEXT : Color.TEXT_MEDIUM
         }),
         onTouched: (e) =>
         {
@@ -886,7 +1015,8 @@ var createMenuButton = (menuFunc, name, height) =>
         }),
         onTouched: (e) =>
         {
-            if(e.type == TouchType.SHORTPRESS_RELEASED || e.type == TouchType.LONGPRESS_RELEASED)
+            if(e.type == TouchType.SHORTPRESS_RELEASED ||
+                e.type == TouchType.LONGPRESS_RELEASED)
             {
                 frame.borderColor = Color.MINIGAME_TILE_BORDER;
                 Sound.playClick();
@@ -923,7 +1053,8 @@ var createClickableVariableButton = (variable, callback, height) =>
         }),
         onTouched: (e) =>
         {
-            if(e.type == TouchType.SHORTPRESS_RELEASED || e.type == TouchType.LONGPRESS_RELEASED)
+            if(e.type == TouchType.SHORTPRESS_RELEASED ||
+                e.type == TouchType.LONGPRESS_RELEASED)
             {
                 Sound.playClick();
                 frame.borderColor = Color.MINIGAME_TILE_BORDER;
@@ -1091,7 +1222,8 @@ var createConfigMenu = () =>
         horizontalOptions: LayoutOptions.END,
         onTouched: (e) =>
         {
-            if(e.type == TouchType.SHORTPRESS_RELEASED || e.type == TouchType.LONGPRESS_RELEASED)
+            if(e.type == TouchType.SHORTPRESS_RELEASED ||
+                e.type == TouchType.LONGPRESS_RELEASED)
             {
                 Sound.playClick();
                 tmpCFC = !tmpCFC;

--- a/renderer.js
+++ b/renderer.js
@@ -601,108 +601,132 @@ var manualPages =
 [
     {
         title: 'The Main Screen',
-        contents: `The main screen consists of the renderer and its controls.
-        \n\nLevel: the system's level. Pressing + or - will derive/revert the 
-        system respectively. Pressing the Level button will reveal all levels 
-        of the system.
-        \n\nTickspeed: controls the renderer's drawing speed (up to 10 lines/
-        sec, which produces less accurate lines).
-        \nPressing the Tickspeed button will toggle between Tick delay and 
-        Tickspeed modes.
-        \n(Tip: holding + or - will buy/refund a variable in bulk.)
-        \n\nReroll: located on the top right. Pressing this button will reroll the system's seed (for stochastic systems).`
+        contents: 
+`The main screen consists of the renderer and its controls.
+
+Level: the system's level. Pressing + or - will derive/revert the system ` +
+`respectively. Pressing the Level button will reveal all levels of the system.
+
+Tickspeed: controls the renderer's drawing speed (up to 10 lines/sec, which ` +
+`produces less accurate lines).
+Pressing the Tickspeed button will toggle between Tick delay and Tickspeed ` +
+`modes.
+(Tip: holding + or - will buy/refund a variable in bulk.)
+
+Reroll: located on the top right. Pressing this button will reroll the ` +
+`system's seed (for stochastic systems).`
     },
     {
         title: 'A Primer on L-systems',
-        contents: `Developed in 1968 by biologist Aristid Lindenmayer, an 
-        L-system is a formal grammar that describes the growth of a sequence 
-        (string). It is often used to model plants and draw fractal figures.
-        \n\nTerms:
-        \nAxiom: the starting sequence.
-        \nRules: how each symbol in the sequence is derived per level. Each rule is written in the form of: {symbol}={derivation(s)}
-        \n\nSymbols:
-        \nAny letter: moves cursor forward to draw.
-        \n+ -: rotates cursor on the z-axis (yaw), counter-/clockwise 
-        respectively.
-        \n& ^: rotates cursor on the y-axis (pitch).
-        \n\\ /: rotates cursor on the x-axis (roll).
-        \n|: reverses cursor direction.
-        \n[ ]: allows for branches by queueing cursor positions on a stack.
-        \n, : separates between derivations (for stochastic systems).`
+        contents:
+`Developed in 1968 by biologist Aristid Lindenmayer, an L-system is a formal ` +
+`grammar that describes the growth of a sequence (string). It is often used ` +
+`to model plants and draw fractal figures.
+
+Terms:
+Axiom: the starting sequence.
+Rules: how each symbol in the sequence is derived per level. Each rule is ` +
+`written in the form of: {symbol}={derivation(s)}
+
+Symbols:
+Any letter: moves cursor forward to draw.
++ -: rotates cursor on the z-axis (yaw), counter-/clockwise respectively.
+& ^: rotates cursor on the y-axis (pitch).
+\\ /: rotates cursor on the x-axis (roll).
+|: reverses cursor direction.
+[ ]: allows for branches by queueing cursor positions on a stack.
+, : separates between derivations (for stochastic systems).`
     },
     {
         title: 'Tips on Constructing an L-system',
-        contents: `Although traditionally F is used to go forward, each letter 
-        can be used to mean different things, such as drawing a flower, 
-        emulating growth stages, alternating between patterns, etc.
-        \n\nFor some simple systems, a symbol (often X) is used to resemble the 
-        fractal's shape.
-        \n\nBrackets work in a stack mechanism, therefore every [ has to be 
-        properly followed by a ] in the same production rule.
-        \n\nTo create a stochastic system, simply list several derivations in 
-        the same rule, separated by a , (comma). One of those derivations will 
-        be randomly selected per symbol whenever the system is derived.
-        \nGenerally, to keep a degree of uniformity in the system, it is 
-        advised for the derivations to be similar in shape.`
+        contents: 
+`Although traditionally F is used to go forward, each letter can be used to ` +
+`mean different things, such as drawing a flower, emulating growth stages, ` +
+`alternating between patterns, etc.
+
+For some simple systems, a symbol (often X) is used to resemble the ` +
+`fractal's shape.
+
+Brackets work in a stack mechanism, therefore every [ has to be properly ` +
+`followed by a ] in the same production rule.
+
+To create a stochastic system, simply list several derivations in the same ` +
+`rule, separated by a , (comma). One of those derivations will be randomly ` +
+`selected per symbol whenever the system is derived.
+Generally, to keep a degree of uniformity in the system, it is advised for ` +
+`the derivations to be similar in shape.`
     },
     {
         title: 'Configuring your L-system',
-        contents: `Configure the visual representation of your L-system with 
-        the renderer menu.
-        \n\nInitial scale: zooms out by this much for every figure.
-        \nFigure scale: zooms the figure out by a multiplier per level.
-        \n\nCamera mode: toggles between static and cursor-focused.
-        \nCentre: sets camera position for level 0 (this follows figure scale, 
-        and is based on non-upright coordinates).
-        \nCamera follow factor: changes how quickly the camera chases the 
-        cursor.
-        \n(Note: figure scale and camera centre needs to be experimented 
-        manually for each individual L-system.)
-        \n\nLooping mode: Level repeats a single level, while Playlist draws 
-        levels consecutively.
-        \nUpright x-axis: rotates figure by 90 degrees counter-clockwise around 
-        the z-axis.
-        \n\nQuickdraw: skips over consecutive straight lines.
-        \nQuick backtrack: similarly, but on the way back.
-        \nBacktrack list: sets stopping symbols for quickdraw/backtrack.`
+        contents:
+`Configure the visual representation of your L-system with the renderer menu.
+
+Initial scale: zooms out by this much for every figure.
+Figure scale: zooms the figure out by a multiplier per level.
+
+Camera mode: toggles between static and cursor-focused.
+Centre: sets camera position for level 0 (this follows figure scale, and is ` +
+`based on non-upright coordinates).
+Camera follow factor: changes how quickly the camera chases the cursor.
+(Note: figure scale and camera centre needs to be experimented manually for ` +
+`each individual L-system.)
+
+Looping mode: Level mode repeats a single level, while the Playlist mode ` +
+`draws levels consecutively.
+Upright x-axis: rotates figure by 90 degrees counter-clockwise around the ` +
+`z-axis.
+
+Quickdraw: skips over consecutive straight lines.
+Quick backtrack: similarly, but on the way back.
+Backtrack list: sets stopping symbols for quickdraw/backtrack.`
     },
     {
         title: 'Example: Arrow weed',
-        contents: `Meet the default system. It tastes like mint.
-        \n\nAxiom: X
-        \nF=FF
-        \nX=F[+X][-X]FX
-        \nTurning angle: 30°
-        \n\nApplies static camera:
-        \nScale: 1, 2
-        \nCentre: (1, 0, 0)`,
+        contents:
+`Meet the default system. It tastes like mint.
+
+Axiom: X
+F=FF
+X=F[+X][-X]FX
+Turning angle: 30°
+
+Applies static camera:
+Scale: 1, 2
+Centre: (1, 0, 0)`,
         system: arrow,
         config: [1, 2, 1, 0, 0, false]
     },
     {
         title: 'Example: Dragon curve',
-        contents: `Also known as the Heighway dragon.
-        \n\nAxiom: FX
-        \nY=-FX-Y
-        \nX=X+YF+
-        \nTurning angle: 90°
-        \n\nApplies static camera:
-        \nScale: 4, sqrt(2)
-        \nCentre: (0, 0, 0)`,
+        contents:
+`Also known as the Heighway dragon.
+
+Axiom: FX
+Y=-FX-Y
+X=X+YF+
+Turning angle: 90°
+
+Applies static camera:
+Scale: 4, sqrt(2)
+Centre: (0, 0, 0)`,
         system: new LSystem('FX', ['Y=-FX-Y', 'X=X+YF+'], 90),
         config: [4, Math.sqrt(2), 0, 0, 0, false]
     },
     {
         title: 'Example: Stochastic weed',
-        contents: `It generates a random shape every time it rolls!
-        \n\nAxiom: X
-        \nF=FF
-        \nX=F-[[X]+X]+F[+FX]-X,
-        \n     F+[[X]-X]-F[-FX]+X
-        \nTurning angle: 22.5°
-        \n\nApplies static camera:
-        \nScale: 1, 2
-        \nCamera centre: (1, 0, 0)`,
+        contents:
+`It generates a random shape every time it rolls!
+
+Axiom: X
+F=FF
+X=F-[[X]+X]+F[+FX]-X,
+     F+[[X]-X]-F[-FX]+X
+Turning angle: 22.5°
+
+Applies static camera:
+Scale: 1, 2
+Centre: (1, 0, 0)
+Upright`,
         system: new LSystem('X', [
             'F=FF',
             'X=F-[[X]+X]+F[+FX]-X,F+[[X]-X]-F[-FX]+X'
@@ -711,26 +735,31 @@ var manualPages =
     },
     {
         title: 'Example: Lucky flower',
-        contents: `How tall can it grow until it sprouts a flower? Reroll to 
-        find out!
-        \n\nAxiom: A
-        \nA=I[L]B,
-        \n     I[L]A,
-        \n     I[L][R]B,
-        \n     IF
-        \nB=I[R]A,
-        \n     I[R]B,
-        \n     I[L][R]A,
-        \n     IF
-        \nL=---I,
-        \n     --I,
-        \n     ----I
-        \nR=+++I,
-        \n     ++I,
-        \n     ++++I
-        \nF=[---[I+I]--I+I][+++[I-I]++I-I]I
-        \nTurning angle: 12°
-        \n\nApplies a mathematically unproven static camera configuration.`,
+        contents:
+`How tall can it grow until it sprouts a flower? Reroll to find out!
+
+Axiom: A
+A=I[L]B,
+     I[L]A,
+     I[L][R]B,
+     IF
+B=I[R]A,
+     I[R]B,
+     I[L][R]A,
+     IF
+L=---I,
+     --I,
+     ----I
+R=+++I,
+     ++I,
+     ++++I
+F=[---[I+I]--I+I][+++[I-I]++I-I]I
+Turning angle: 12°
+
+Applies static camera:
+Scale: 6, 1
+Centre: (0.7, 0, 0)
+Upright`,
         system: new LSystem('A', [
             'A=I[L]B,I[L]A,I[L][R]B,IF',
             'B=I[R]A,I[R]B,I[L][R]A,IF',
@@ -738,14 +767,27 @@ var manualPages =
             'R=+++I,++I,++++I',
             'F=[---[I+I]--I+I][+++[I-I]++I-I]I'
         ], 12),
-        config: [6, 1, 0.6, 0, 0, true]
+        config: [6, 1, 0.7, 0, 0, true]
     },
     {
         title: 'Example: Blackboard tree (3D)',
-        contents: `A blackboard tree (Alstonia scholaris) when it's still tiny.
-        \n\nAxiom: F\nF=Y[++++++MF][-----NF][^^^^^OF][&&&&&PF]\nM=Z-M\nN=Z
-        +N\nO=Z&O\nP=Z^P\nY=Z-ZY+\nZ=ZZ\nTurning angle: 8°\n\nScale: 2, 
-        2\nCamera centre: (1.5, 0, 0)`,
+        contents:
+`A blackboard tree (Alstonia scholaris) when it's still tiny.
+
+Axiom: F
+F=Y[++++++MF][-----NF][^^^^^OF][&&&&&PF]
+M=Z-M
+N=Z+N
+O=Z&O
+P=Z^P
+Y=Z-ZY+
+Z=ZZ
+Turning angle: 8°
+
+Applies static camera:
+Scale: 2, 2
+Centre: (1.5, 0, 0)
+Upright`,
         system: new LSystem('F', [
             'F=Y[++++++MF][-----NF][^^^^^OF][&&&&&PF]',
             'M=Z-M',
@@ -759,9 +801,17 @@ var manualPages =
     },
     {
         title: 'Example: Hilbert curve (3D)',
-        contents: `If you set to high tickspeed, it look like brainz.\n\nAxiom: 
-        X\nX=^/XF^/XFX-F^\\\\XFX&F+\\\\XFX-F\\X-\\\nTurning angle: 90°\nIgnore: 
-        X\n\nScale: 1, 2\nCamera centre: (0.5, -0.5, -0.5)`,
+        contents:
+`If you set to high tickspeed, it look like brainz.
+
+Axiom: X
+X=^/XF^/XFX-F^\\\\XFX&F+\\\\XFX-F\\X-\\
+Turning angle: 90°
+Ignore: X
+
+Applies static camera:
+Scale: 1, 2
+Centre: (0.5, -0.5, -0.5)`,
         system: new LSystem('X', [
             'X',
             'X=^/XF^/XFX-F^\\\\XFX&F+\\\\XFX-F\\X-\\'
@@ -770,10 +820,19 @@ var manualPages =
     },
     {
         title: 'Example: Fern (3D)',
-        contents: `Source: https://observablehq.com/@kelleyvanevert/
-        3d-l-systems\n\nAxiom: FFFA\nA=[++++++++++++++FC]B^+B[--------------FD]B
-        +BA\nC=[---------FF][+++++++++FF]B&&+C\nD=[---------FF][+++++++++FF]B&&
-        -D\nTurning angle: 4°`,
+        contents:
+`Source: https://observablehq.com/@kelleyvanevert/3d-l-systems
+
+Axiom: FFFA
+A=[++++++++++++++FC]B^+B[--------------FD]B+BA
+C=[---------FF][+++++++++FF]B&&+C
+D=[---------FF][+++++++++FF]B&&-D
+Turning angle: 4°
+
+Applies static camera: (mathematically unproven)
+Scale: 3, 1.3
+Centre: (0.6, 0, 0)
+Upright`,
         system: new LSystem('FFFA', [
             'A=[++++++++++++++FC]B^+B[--------------FD]B+BA',
             'C=[---------FF][+++++++++FF]B&&+C',
@@ -783,28 +842,56 @@ var manualPages =
     },
     {
         title: 'Example: Cultivar FF (Botched)',
-        contents: `Represents a common source of carbohydrates.\n\nAxiom: 
-        X\nF=FF\nX=F-[[X]+X]+F[-X]-X\nTurning angle: 15°\n\nScale: 1, 2\nCamera 
-        centre: (1, 0, 0)`,
+        contents:
+`Represents a common source of carbohydrates.
+
+Axiom: X
+F=FF
+X=F-[[X]+X]+F[-X]-X
+Turning angle: 15°
+
+Applies static camera:
+Scale: 1, 2
+Centre: (1, 0, 0)
+Upright`,
         system: new LSystem('X', ['F=FF', 'X=F-[[X]+X]+F[-X]-X'], 15),
         config: [1, 2, 1, 0, 0, true]
     },
     {
         title: 'Example: Cultivar FXF (Botched)',
-        contents: `Commonly called the Cyclone, cultivar FXF resembles a coil 
-        of barbed wire. Legends have it, once a snake moult has weathered 
-        enough, a new life is born unto the tattered husk, and from there, it 
-        stretches.\n\nAxiom: X\nF=F[+F]XF\nX=F-[[X]+X]+F[-FX]-X\nTurning angle: 
-        27°`,
+        contents:
+`Commonly called the Cyclone, cultivar FXF resembles a coil of barbed wire. ` +
+`Legends have it, once a snake moult has weathered enough, a new life is ` +
+`born unto the tattered husk, and from there, it stretches.
+
+Axiom: X
+F=F[+F]XF
+X=F-[[X]+X]+F[-FX]-X
+Turning angle: 27°
+
+Applies static camera: (mathematically unproven)
+Scale: 1.5, 2
+Centre: (0.15, -0.5, 0)`,
         system: new LSystem('X', ['F=F[+F]XF', 'X=F-[[X]+X]+F[-FX]-X'], 27),
         config: [1.5, 2, 0.15, -0.5, 0, false]
     },
     {
         title: 'Example: Cultivar XEXF (Botched)',
-        contents: `Bearing the shape of a thistle, cultivar XEXF embodies the 
-        strength and resilience of nature against the harsh logarithm drop-off. 
-        It also smells really, really good.\n\nAxiom: X\nE=XEXF-\nF=FX+[E]
-        X\nX=F-[X+[X[++E]F]]+F[X+FX]-X\nTurning angle: 22.5°`,
+        contents:
+`Bearing the shape of a thistle, cultivar XEXF embodies the strength and ` +
+`resilience of nature against the harsh logarithm drop-off. It also smells ` +
+`really, really good.
+
+Axiom: X
+E=XEXF-
+F=FX+[E]X
+X=F-[X+[X[++E]F]]+F[X+FX]-X
+Turning angle: 22.5°
+
+Applies static camera: (mathematically unproven)
+Scale: 1, 3
+Centre: (0,75, -0,25, 0)
+Upright`,
         system: new LSystem('X', [
             'E=XEXF-',
             'F=FX+[E]X',
@@ -849,8 +936,8 @@ var init = () =>
         let getDesc = (level) =>
         {
             if(tickDelayMode)
-                return `\\text{Tick delay: }${(level / 10).toString()}
-                \\text{ sec}`;
+                return `\\text{Tick delay: }${(level / 10).toString()}` +
+                `\\text{ sec}`;
             return `\\text{Tickspeed: }${level.toString()}/\\text{sec}`;
         }
         let getInfo = (level) => `\\text{Ts=}${level.toString()}/s`;
@@ -2229,8 +2316,8 @@ var createManualMenu = () =>
                                 {
                                     Sound.playClick();
                                     --page;
-                                    menu.title = `Manual (${page + 1}/
-                                    ${manualPages.length})`;
+                                    menu.title = `Manual (${page + 1}/` +
+                                    `${manualPages.length})`;
                                     pageTitle.text = manualPages[page].title;
                                     pageContents.text =
                                     manualPages[page].contents;
@@ -2267,8 +2354,8 @@ var createManualMenu = () =>
                                 if(page < manualPages.length - 1)
                                 {
                                     ++page;
-                                    menu.title = `Manual (${page + 1}/
-                                    ${manualPages.length})`;
+                                    menu.title = `Manual (${page + 1}/` +
+                                    `${manualPages.length})`;
                                     pageTitle.text = manualPages[page].title;
                                     pageContents.text =
                                     manualPages[page].contents;
@@ -2310,7 +2397,7 @@ var createSequenceMenu = () =>
 
     let menu = ui.createPopup
     ({
-        title: `Sequences Menu`,
+        title: 'Sequences Menu',
         content: ui.createStackLayout
         ({
             children:

--- a/renderer.js
+++ b/renderer.js
@@ -226,8 +226,8 @@ class Quaternion
      */
     toString()
     {
-        return `${getCoordString(this.w)} + ${getCoordString(this.x)}i + 
-        ${getCoordString(this.y)}j + ${getCoordString(this.z)}k`;
+        return `${getCoordString(this.w)} + ${getCoordString(this.x)}i + ` +
+        `${getCoordString(this.y)}j + ${getCoordString(this.z)}k`;
     }
 }
 
@@ -305,8 +305,8 @@ class LSystem
 
     toString()
     {
-        let result = `${this.axiom} ${this.turnAngle} ${this.seed} 
-        ${this.ignoreList}`;
+        let result = `${this.axiom} ${this.turnAngle} ${this.seed} ` +
+        `${this.ignoreList}`;
         for(let [key, value] of this.rules)
         {
             if(typeof value === 'string')
@@ -352,7 +352,7 @@ class Renderer
 
     update(level, seedChanged = false)
     {
-        let clearGraph = this.loopMode != 2 && level <= this.lvl;
+        let clearGraph = this.loopMode != 2 || level <= this.lvl;
         let start = seedChanged ? 0 : this.levels.length;
         let charCount = 0;
         for(let i = start; i <= level; ++i)
@@ -562,28 +562,28 @@ class Renderer
     }
     getProgressString()
     {
-        return `i=${Math.max(this.idx - 1, 0)}/
-        ${this.levels[this.lvl].length - 2}&
-        (${getCoordString(this.getProgress())}\\%)`;
+        return `i=${Math.max(this.idx - 1, 0)}/` +
+        `${this.levels[this.lvl].length - 2}&` +
+        `(${getCoordString(this.getProgress())}\\%)`;
     }
     getStateString()
     {
-        return `\\begin{matrix}x=${getCoordString(this.state.x)},&y=
-        ${getCoordString(this.state.y)},&z=${getCoordString(this.state.z)},&
-        ${this.getProgressString()}\\end{matrix}`;
+        return `\\begin{matrix}x=${getCoordString(this.state.x)},&y=` +
+        `${getCoordString(this.state.y)},&z=${getCoordString(this.state.z)},&` +
+        `${this.getProgressString()}\\end{matrix}`;
     }
     getOriString()
     {
-        return `\\begin{matrix}q=${this.ori.toString()},&
-        ${this.getProgressString()}\\end{matrix}`;
+        return `\\begin{matrix}q=${this.ori.toString()},&` +
+        `${this.getProgressString()}\\end{matrix}`;
     }
     toString()
     {
-        return`${this.initScale} ${this.figureScale} 
-        ${this.cursorFocused ? 1 : 0} ${this.camera.x} ${this.camera.y} 
-        ${this.camera.z} ${this.followFactor} ${this.loopMode} 
-        ${this.upright ? 1 : 0} ${this.quickDraw ? 1 : 0} 
-        ${this.quickBacktrack ? 1 : 0} ${this.backtrackList}`;
+        return`${this.initScale} ${this.figureScale} ` +
+        `${this.cursorFocused ? 1 : 0} ${this.camera.x} ${this.camera.y} ` +
+        `${this.camera.z} ${this.followFactor} ${this.loopMode} ` +
+        `${this.upright ? 1 : 0} ${this.quickDraw ? 1 : 0} ` +
+        `${this.quickBacktrack ? 1 : 0} ${this.backtrackList}`;
     }
 }
 
@@ -602,36 +602,43 @@ var manualPages =
     {
         title: 'The Main Screen',
         contents: `The main screen consists of the renderer and its controls.
-        \n\nLevel: the system\'s level. Pressing + or - will derive/revert the 
+        \n\nLevel: the system's level. Pressing + or - will derive/revert the 
         system respectively. Pressing the Level button will reveal all levels 
-        of the system.\n\nTickspeed: controls the renderer\'s drawing speed (up 
-        to 10 lines/sec, which produces less accurate lines).\nPressing the 
-        Tickspeed button will toggle between tick delay and tickspeed mode.\n
-        (Tip: holding + or - will buy/refund a variable in bulk.)\n\nReroll: 
-        located on the top right. Pressing this button will reroll the 
-        system\'s seed (for stochastic systems).`
+        of the system.
+        \n\nTickspeed: controls the renderer's drawing speed (up to 10 lines/
+        sec, which produces less accurate lines).
+        \nPressing the Tickspeed button will toggle between Tick delay and 
+        Tickspeed modes.
+        \n(Tip: holding + or - will buy/refund a variable in bulk.)
+        \n\nReroll: located on the top right. Pressing this button will reroll the system's seed (for stochastic systems).`
     },
     {
         title: 'A Primer on L-systems',
         contents: `Developed in 1968 by biologist Aristid Lindenmayer, an 
         L-system is a formal grammar that describes the growth of a sequence 
         (string). It is often used to model plants and draw fractal figures.
-        \n\nTerms:\nAxiom: the starting sequence.\nRules: how each symbol in 
-        the sequence is derived per level. Each rule is written in the form of: 
-        {symbol}={derivation(s)}\n\nSymbols:\nAny letter: moves cursor forward 
-        to draw.\n+ -: rotates cursor on the z-axis (yaw), counter-/clockwise 
-        respectively.\n& ^: rotates cursor on the y-axis (pitch).\n\\ /: 
-        rotates cursor on the x-axis (roll).\n|: reverses cursor direction.\n[ ]
-        : allows for branches by queueing cursor positions on a stack.\n, : 
-        separates between derivations (for stochastic systems).`
+        \n\nTerms:
+        \nAxiom: the starting sequence.
+        \nRules: how each symbol in the sequence is derived per level. Each rule is written in the form of: {symbol}={derivation(s)}
+        \n\nSymbols:
+        \nAny letter: moves cursor forward to draw.
+        \n+ -: rotates cursor on the z-axis (yaw), counter-/clockwise 
+        respectively.
+        \n& ^: rotates cursor on the y-axis (pitch).
+        \n\\ /: rotates cursor on the x-axis (roll).
+        \n|: reverses cursor direction.
+        \n[ ]: allows for branches by queueing cursor positions on a stack.
+        \n, : separates between derivations (for stochastic systems).`
     },
     {
         title: 'Tips on Constructing an L-system',
-        contents: `Each letter can be used to mean different things, such as 
-        drawing a flower, emulating growth stages, alternating between 
-        patterns, etc.\nTraditionally, F is used to mean forward, and X to 
-        create new branches.\n\nBrackets work in a stack mechanism, therefore 
-        every [ has to be properly followed by a ] in the same production rule.
+        contents: `Although traditionally F is used to go forward, each letter 
+        can be used to mean different things, such as drawing a flower, 
+        emulating growth stages, alternating between patterns, etc.
+        \n\nFor some simple systems, a symbol (often X) is used to resemble the 
+        fractal's shape.
+        \n\nBrackets work in a stack mechanism, therefore every [ has to be 
+        properly followed by a ] in the same production rule.
         \n\nTo create a stochastic system, simply list several derivations in 
         the same rule, separated by a , (comma). One of those derivations will 
         be randomly selected per symbol whenever the system is derived.
@@ -641,40 +648,61 @@ var manualPages =
     {
         title: 'Configuring your L-system',
         contents: `Configure the visual representation of your L-system with 
-        the renderer menu.\n\nInitial scale: zooms out by this much for every 
-        figure.\nFigure scale: zooms the figure out by a multiplier per level.
-        \n\nCamera mode: toggles between static and cursor-focused.\nCentre: 
-        sets camera position for level 0 (this follows figure scale, and is 
-        based on non-upright coordinates).\nCamera follow factor: changes how 
-        quickly the camera chases the cursor.\n(Note: figure scale and camera 
-        centre needs to be experimented manually for each individual L-system.)
-        \n\nOffline drawing: when enabled, no longer resets the graph while 
-        tabbed out.\nUpright x-axis: rotates figure by 90 degrees 
-        counter-clockwise around the z-axis.\n\nQuickdraw: skips over 
-        consecutive straight lines.\nQuick backtrack: similarly, but on the way 
-        back.\nBacktrack list: sets stopping symbols for quickdraw/backtrack.`
+        the renderer menu.
+        \n\nInitial scale: zooms out by this much for every figure.
+        \nFigure scale: zooms the figure out by a multiplier per level.
+        \n\nCamera mode: toggles between static and cursor-focused.
+        \nCentre: sets camera position for level 0 (this follows figure scale, 
+        and is based on non-upright coordinates).
+        \nCamera follow factor: changes how quickly the camera chases the 
+        cursor.
+        \n(Note: figure scale and camera centre needs to be experimented 
+        manually for each individual L-system.)
+        \n\nLooping mode: Level repeats a single level, while Playlist draws 
+        levels consecutively.
+        \nUpright x-axis: rotates figure by 90 degrees counter-clockwise around 
+        the z-axis.
+        \n\nQuickdraw: skips over consecutive straight lines.
+        \nQuick backtrack: similarly, but on the way back.
+        \nBacktrack list: sets stopping symbols for quickdraw/backtrack.`
     },
     {
         title: 'Example: Arrow weed',
-        contents: `Meet the default system. It tastes like mint.\n\nAxiom: 
-        X\nF=FF\nX=F[+X][-X]FX\nTurning angle: 30°\n\nScale: 1, 2\nCamera 
-        centre: (1, 0, 0)`,
+        contents: `Meet the default system. It tastes like mint.
+        \n\nAxiom: X
+        \nF=FF
+        \nX=F[+X][-X]FX
+        \nTurning angle: 30°
+        \n\nApplies static camera:
+        \nScale: 1, 2
+        \nCentre: (1, 0, 0)`,
         system: arrow,
         config: [1, 2, 1, 0, 0, false]
     },
     {
         title: 'Example: Dragon curve',
-        contents: `Also known as the Heighway dragon.\n\nAxiom: FX\nY=-FX-Y\nX=X
-        +YF+\nTurning angle: 90°\n\nScale: 2, sqrt(2)\nCamera centre: (0, 0, 0)
-        `,
+        contents: `Also known as the Heighway dragon.
+        \n\nAxiom: FX
+        \nY=-FX-Y
+        \nX=X+YF+
+        \nTurning angle: 90°
+        \n\nApplies static camera:
+        \nScale: 4, sqrt(2)
+        \nCentre: (0, 0, 0)`,
         system: new LSystem('FX', ['Y=-FX-Y', 'X=X+YF+'], 90),
-        config: [2, Math.sqrt(2), 0, 0, 0, false]
+        config: [4, Math.sqrt(2), 0, 0, 0, false]
     },
     {
         title: 'Example: Stochastic weed',
-        contents: `It generates a random shape every time it rolls!\n\nAxiom: 
-        F\nF=FF\nX=F-[[X]+X]+F[+FX]-X,\n     F+[[X]-X]-F[-FX]+X\nTurning angle: 
-        22.5°\n\nScale: 1, 2\nCamera centre: (1, 0, 0)`,
+        contents: `It generates a random shape every time it rolls!
+        \n\nAxiom: X
+        \nF=FF
+        \nX=F-[[X]+X]+F[+FX]-X,
+        \n     F+[[X]-X]-F[-FX]+X
+        \nTurning angle: 22.5°
+        \n\nApplies static camera:
+        \nScale: 1, 2
+        \nCamera centre: (1, 0, 0)`,
         system: new LSystem('X', [
             'F=FF',
             'X=F-[[X]+X]+F[+FX]-X,F+[[X]-X]-F[-FX]+X'
@@ -684,10 +712,25 @@ var manualPages =
     {
         title: 'Example: Lucky flower',
         contents: `How tall can it grow until it sprouts a flower? Reroll to 
-        find out!\n\nAxiom: A\nA=I[L]B,\n     I[L]A,\n     I[L][R]B,\n     
-        IF\nB=I[R]A,\n     I[R]B,\n     I[L][R]A,\n     IF\nL=---I,\n     --I,
-        \n     ----I\nR=+++I,\n     ++I,\n     ++++I\nF=[---[I+I]--I+I][+++[I-I]
-        ++I-I]I\nTurning angle: 12°`,
+        find out!
+        \n\nAxiom: A
+        \nA=I[L]B,
+        \n     I[L]A,
+        \n     I[L][R]B,
+        \n     IF
+        \nB=I[R]A,
+        \n     I[R]B,
+        \n     I[L][R]A,
+        \n     IF
+        \nL=---I,
+        \n     --I,
+        \n     ----I
+        \nR=+++I,
+        \n     ++I,
+        \n     ++++I
+        \nF=[---[I+I]--I+I][+++[I-I]++I-I]I
+        \nTurning angle: 12°
+        \n\nApplies a mathematically unproven static camera configuration.`,
         system: new LSystem('A', [
             'A=I[L]B,I[L]A,I[L][R]B,IF',
             'B=I[R]A,I[R]B,I[L][R]A,IF',
@@ -695,11 +738,11 @@ var manualPages =
             'R=+++I,++I,++++I',
             'F=[---[I+I]--I+I][+++[I-I]++I-I]I'
         ], 12),
-        config: [3, 1.1, 0.7, 0, 0, true]
+        config: [6, 1, 0.6, 0, 0, true]
     },
     {
         title: 'Example: Blackboard tree (3D)',
-        contents: `A blackboard tree (Alstonia scholaris) when it\'s still tiny.
+        contents: `A blackboard tree (Alstonia scholaris) when it's still tiny.
         \n\nAxiom: F\nF=Y[++++++MF][-----NF][^^^^^OF][&&&&&PF]\nM=Z-M\nN=Z
         +N\nO=Z&O\nP=Z^P\nY=Z-ZY+\nZ=ZZ\nTurning angle: 8°\n\nScale: 2, 
         2\nCamera centre: (1.5, 0, 0)`,
@@ -2299,8 +2342,8 @@ var createSequenceMenu = () =>
 
 var getInternalState = () =>
 {
-    let result = `${version} ${time} ${page} ${offlineDrawing ? 1 : 0} 
-    ${altCurrencies ? 1 : 0} ${tickDelayMode ? 1 : 0}`;
+    let result = `${version} ${time} ${page} ${offlineDrawing ? 1 : 0} ` +
+    `${altCurrencies ? 1 : 0} ${tickDelayMode ? 1 : 0}`;
     result += `\n${renderer.toString()}\n${renderer.system.toString()}`;
     for(let [key, value] of savedSystems)
     {
@@ -2318,7 +2361,8 @@ var setInternalState = (stateStr) =>
         time = parseBigNumber(worldValues[1]);
     if(worldValues.length > 2)
         page = Number(worldValues[2]);
-    // Offline Drawing
+    if(worldValues.length > 3)
+        offlineDrawing = Boolean(Number(worldValues[3]));
     if(worldValues.length > 4)
         altCurrencies = Boolean(Number(worldValues[4]));
     if(worldValues.length > 5)

--- a/renderer.js
+++ b/renderer.js
@@ -724,7 +724,7 @@ class Renderer
      * Computes the next cursor position internally.
      * @param {number} level the level to be drawn.
      */
-    draw(level)
+    draw(level, onlyUpdate = false)
     {
         /*
         I can guarantee that because the game runs on one thread, the renderer
@@ -734,6 +734,9 @@ class Renderer
             this.update(level);
 
         if(level > this.loaded + 1)
+            return;
+
+        if(onlyUpdate)
             return;
 
         if(this.elapsed == 0)
@@ -1319,6 +1322,9 @@ var alwaysShowRefundButtons = () => true;
 
 var timeCheck = (elapsedTime) =>
 {
+    if(ts.level == 0)
+        return false;
+
     if(tickDelayMode)
     {
         time += 1;
@@ -1330,9 +1336,6 @@ var timeCheck = (elapsedTime) =>
 
 var tick = (elapsedTime, multiplier) =>
 {
-    if(ts.level == 0)
-        return;
-
     if(timeCheck(elapsedTime))
     {
         if(game.isCalculatingOfflineProgress)
@@ -1346,33 +1349,25 @@ var tick = (elapsedTime, multiplier) =>
         }
 
         if(!gameIsOffline || offlineDrawing)
-        {
             renderer.draw(l.level);
-            // if(altCurrencies)
-            // {
-            //     roll.value = renderer.state.x;
-            //     pitch.value = renderer.state.y;
-            //     yaw.value = renderer.state.z;
-            // }
-            // else
-            // {
-            //     let angles = renderer.getAngles();
-            //     yaw.value = angles.z;
-            //     pitch.value = angles.y;
-            //     roll.value = angles.x;
-            // }
-            progress.value = renderer.getProgressPercent();
-            theory.invalidateTertiaryEquation();
-        }
+
         if(tickDelayMode)
             time = 0;
         else
             time -= 1 / ts.level;
     }
-    
-    renderer.tick(elapsedTime);
+    else
+    {
+        // Updates have to be at full speed
+        renderer.draw(l.level, true);
+    }
+
+    if(ts.level > 0)
+        renderer.tick(elapsedTime);
     let msTime = renderer.getElapsedTime();
     min.value = msTime[0] + msTime[1] / 100;
+    progress.value = renderer.getProgressPercent();
+    theory.invalidateTertiaryEquation();
 }
 
 var getEquationOverlay = () =>

--- a/renderer.js
+++ b/renderer.js
@@ -76,7 +76,7 @@ const locStrings =
     {
         rendererLoading: '\\begin{{matrix}}Loading...&\\text{{Lv. {0}}}&({1}\\text{{} chars}})\\end{{matrix}}',
 
-        elapsedCurrency: ' (elapsed)',
+        currencyTime: ' (elapsed)',
         varLvDesc: '\\text{{Level: }}{0}{1}',
         varTdDesc: '\\text{{Tick delay: }}{0}\\text{{ sec}}',
         varTdDescInf: '\\text{{Tick delay: }}\\infty',
@@ -87,62 +87,62 @@ const locStrings =
         'playlist.',
         saPatienceHint: 'Be patient.',
 
-        overlayTitle: 'v0.19: Winter Sweep (WIP)',
+        equationOverlay: 'v0.19: Winter Sweep (WIP)',
 
-        sysButton: 'L-system menu',
-        cfgButton: 'Renderer menu',
-        slButton: 'Save/load',
-        worldButton: 'Theory settings',
-        manualButton: 'Manual',
+        btnSave: 'Save',
+        btnDefault: 'Reset to Defaults',
+        btnAdd: 'Add',
+        btnConstruct: 'Construct',
+        btnDelete: 'Delete',
+        btnView: 'View',
+        btnClipboard: 'Clipboard',
+        btnPrev: 'Previous',
+        btnNext: 'Next',
+        btnClose: 'Close',
 
-        saveButton: 'Save',
-        defaultButton: 'Reset to Defaults',
-        addButton: 'Add',
-        constructButton: 'Construct',
-        deleteButton: 'Delete',
-        viewButton: 'View',
-        clipboardButton: 'Clipboard',
-        prevButton: 'Previous',
-        nextButton: 'Next',
-        closeButton: 'Close',
+        btnMenuLSystem: 'L-system menu',
+        btnMenuRenderer: 'Renderer menu',
+        btnMenuSave: 'Save/load',
+        btnMenuTheory: 'Theory settings',
+        btnMenuManual: 'Manual',
 
-        cfgMenuTitle: 'Renderer Menu',
-        iScaleLabel: 'Initial scale: ',
-        fScaleLabel: 'Figure scale per level: ',
-        CFCLabel: 'Camera mode: {0}',
+        menuLSystem: 'L-system Menu',
+        labelAxiom: 'Axiom: ',
+        labelAngle: 'Turning angle (°): ',
+        labelRules: 'Production rules: ',
+        labelIgnored: 'Ignored symbols: ',
+        labelSeed: 'Seed (for stochastic systems): ',
+
+        menuRenderer: 'Renderer Menu',
+        labelInitScale: 'Initial scale: ',
+        labelFigScale: 'Figure scale per level: ',
+        labelCamMode: 'Camera mode: {0}',
         camModes: ['Static', 'Cursor-focused'],
-        camLabel: 'Centre (x, y, z): ',
-        FFLabel: 'Follow factor (0-1): ',
-        LMLabel: 'Looping mode: {0}',
+        labelCamCentre: 'Centre (x, y, z): ',
+        labelFollowFactor: 'Follow factor (0-1): ',
+        labelLoopMode: 'Looping mode: {0}',
         loopModes: ['Off', 'Level', 'Playlist'],
-        uprightLabel: 'Upright x-axis: ',
-        QDLabel: 'Quickdraw straight lines: ',
-        QBLabel: 'Quick backtrack: ',
-        EXBLabel: 'Backtrack list: ',
+        labelUpright: 'Upright x-axis: ',
+        labelQuickdraw: 'Quickdraw straight lines: ',
+        labelQuickBT: 'Quick backtrack: ',
+        labelBTList: 'Backtrack list: ',
 
-        sysMenuTitle: 'L-system Menu',
-        axiomLabel: 'Axiom: ',
-        angleLabel: 'Turning angle (°): ',
-        rulesLabel: 'Production rules: ',
-        ignoreLabel: 'Ignored symbols: ',
-        seedLabel: 'Seed (for stochastic systems): ',
-
-        saveMenuTitle: 'Save/Load Menu',
+        menuSave: 'Save/Load Menu',
         currentSystem: 'Current system: ',
         savedSystems: 'Saved systems: ',
 
-        clipboardMenuTitle: 'Clipboard Menu',
+        menuClipboard: 'Clipboard Menu',
 
-        namingMenuTitle: 'Name System',
+        menuNaming: 'Name System',
         defaultSystemName: 'Untitled L-system',
         duplicateSuffix: ' (copy)',
 
-        worldMenuTitle: 'Theory Settings',
-        ODLabel: 'Offline drawing: ',
-        ACLabel: 'Tertiary equation: {0}',
+        menuTheory: 'Theory Settings',
+        labelOfflineDrawing: 'Offline drawing: ',
+        labelTerEq: 'Tertiary equation: {0}',
         terEqModes: ['Coordinates', 'Orientation'],
 
-        manualMenuTitle: 'Manual ({0}/{1})',
+        menuManual: 'Manual ({0}/{1})',
         manual:
         [
             {
@@ -399,8 +399,8 @@ Upright`
             }
         ],
 
-        seqMenuTitle: 'View Sequences',
-        lvlLabel: 'Level {0}: ',
+        menuSequence: 'View Sequences',
+        labelLevelSeq: 'Level {0}: ',
 
         rerollSeed: 'You are about to reroll the system\'s seed.',
     }
@@ -1428,7 +1428,7 @@ let manualSystems =
 
 var init = () =>
 {
-    min = theory.createCurrency(getLoc('elapsedCurrency'));
+    min = theory.createCurrency(getLoc('currencyTime'));
     progress = theory.createCurrency('%');
 
     // l (Level)
@@ -1530,7 +1530,7 @@ var getEquationOverlay = () =>
 {
     let result = ui.createLatexLabel
     ({
-        text: getLoc('overlayTitle'),
+        text: getLoc('equationOverlay'),
         displacementX: 6,
         displacementY: 4,
         fontSize: 9,
@@ -1744,24 +1744,26 @@ var getUpgradeListDelegate = () =>
     tsButton.row = 1;
     tsButton.column = 0;
 
-    let sysButton = createMenuButton(createSystemMenu, getLoc('sysButton'),
+    let sysButton = createMenuButton(createSystemMenu, getLoc('btnMenuLSystem'),
     height);
     sysButton.row = 0;
     sysButton.column = 0;
-    let cfgButton = createMenuButton(createConfigMenu, getLoc('cfgButton'),
+    let cfgButton = createMenuButton(createConfigMenu,
+    getLoc('btnMenuRenderer'),
     height);
     cfgButton.row = 0;
     cfgButton.column = 1;
-    let slButton = createMenuButton(createSaveMenu, getLoc('slButton'),
+    let slButton = createMenuButton(createSaveMenu, getLoc('btnMenuSave'),
     height);
     slButton.row = 1;
     slButton.column = 0;
-    let worldButton = createMenuButton(createWorldMenu, getLoc('worldButton'),
+    let theoryButton = createMenuButton(createWorldMenu,
+    getLoc('btnMenuTheory'),
     height);
-    worldButton.row = 1;
-    worldButton.column = 1;
+    theoryButton.row = 1;
+    theoryButton.column = 1;
     let manualButton = createMenuButton(createManualMenu,
-    getLoc('manualButton'), height);
+    getLoc('btnMenuManual'), height);
     manualButton.row = 2;
     manualButton.column = 0;
 
@@ -1825,8 +1827,8 @@ var getUpgradeListDelegate = () =>
                         sysButton,
                         cfgButton,
                         slButton,
-                        manualButton,
-                        worldButton
+                        theoryButton,
+                        manualButton
                     ]
                 })
             ]
@@ -1864,7 +1866,7 @@ let createConfigMenu = () =>
     let tmpCFC = renderer.cursorFocused;
     let CFCLabel = ui.createLatexLabel
     ({
-        text: Localization.format(getLoc('CFCLabel'),
+        text: Localization.format(getLoc('labelCamMode'),
         getLoc('camModes')[Number(tmpCFC)]),
         row: 2,
         column: 0,
@@ -1888,7 +1890,7 @@ let createConfigMenu = () =>
                 camGrid.isVisible = !tmpCFC;
                 FFLabel.isVisible = tmpCFC;
                 FFEntry.isVisible = tmpCFC;
-                CFCLabel.text = Localization.format(getLoc('CFCLabel'),
+                CFCLabel.text = Localization.format(getLoc('labelCamMode'),
                 getLoc('camModes')[Number(tmpCFC)]);
             }
         }
@@ -1906,7 +1908,7 @@ let createConfigMenu = () =>
         [
             ui.createLatexLabel
             ({
-                text: getLoc('camLabel'),
+                text: getLoc('labelCamCentre'),
                 row: 0,
                 column: 0,
                 verticalOptions: LayoutOptions.CENTER
@@ -1959,7 +1961,7 @@ let createConfigMenu = () =>
     let tmpFF = renderer.followFactor;
     let FFLabel = ui.createLatexLabel
     ({
-        text: getLoc('FFLabel'),
+        text: getLoc('labelFollowFactor'),
         row: 3,
         column: 0,
         verticalOptions: LayoutOptions.CENTER,
@@ -1980,7 +1982,7 @@ let createConfigMenu = () =>
     let tmpLM = renderer.loopMode;
     let LMLabel = ui.createLatexLabel
     ({
-        text: Localization.format(getLoc('LMLabel'),
+        text: Localization.format(getLoc('labelLoopMode'),
         getLoc('loopModes')[tmpLM]),
         row: 0,
         column: 0,
@@ -1999,7 +2001,7 @@ let createConfigMenu = () =>
         onValueChanged: () =>
         {
             tmpLM = Math.round(LMSlider.value);
-            LMLabel.text = Localization.format(getLoc('LMLabel'),
+            LMLabel.text = Localization.format(getLoc('labelLoopMode'),
             getLoc('loopModes')[tmpLM]);
         },
         onDragCompleted: () =>
@@ -2065,7 +2067,7 @@ let createConfigMenu = () =>
     let tmpEXB = renderer.backtrackList;
     let EXBLabel = ui.createLatexLabel
     ({
-        text: getLoc('EXBLabel'),
+        text: getLoc('labelBTList'),
         row: 4,
         column: 0,
         verticalOptions: LayoutOptions.CENTER
@@ -2083,7 +2085,7 @@ let createConfigMenu = () =>
 
     let menu = ui.createPopup
     ({
-        title: getLoc('cfgMenuTitle'),
+        title: getLoc('menuRenderer'),
         content: ui.createStackLayout
         ({
             children:
@@ -2101,7 +2103,7 @@ let createConfigMenu = () =>
                                 [
                                     ui.createLatexLabel
                                     ({
-                                        text: getLoc('iScaleLabel'),
+                                        text: getLoc('labelInitScale'),
                                         row: 0,
                                         column: 0,
                                         verticalOptions: LayoutOptions.CENTER
@@ -2109,7 +2111,7 @@ let createConfigMenu = () =>
                                     iScaleEntry,
                                     ui.createLatexLabel
                                     ({
-                                        text: getLoc('fScaleLabel'),
+                                        text: getLoc('labelFigScale'),
                                         row: 1,
                                         column: 0,
                                         verticalOptions: LayoutOptions.CENTER
@@ -2138,7 +2140,7 @@ let createConfigMenu = () =>
                                     LMSlider,
                                     ui.createLatexLabel
                                     ({
-                                        text: getLoc('uprightLabel'),
+                                        text: getLoc('labelUpright'),
                                         row: 1,
                                         column: 0,
                                         verticalOptions: LayoutOptions.CENTER
@@ -2146,7 +2148,7 @@ let createConfigMenu = () =>
                                     uprightSwitch,
                                     ui.createLatexLabel
                                     ({
-                                        text: getLoc('QDLabel'),
+                                        text: getLoc('labelQuickdraw'),
                                         row: 2,
                                         column: 0,
                                         verticalOptions: LayoutOptions.CENTER
@@ -2154,7 +2156,7 @@ let createConfigMenu = () =>
                                     QDSwitch,
                                     ui.createLatexLabel
                                     ({
-                                        text: getLoc('QBLabel'),
+                                        text: getLoc('labelQuickBT'),
                                         row: 3,
                                         column: 0,
                                         verticalOptions: LayoutOptions.CENTER
@@ -2179,7 +2181,7 @@ let createConfigMenu = () =>
                     [
                         ui.createButton
                         ({
-                            text: getLoc('saveButton'),
+                            text: getLoc('btnSave'),
                             row: 0,
                             column: 0,
                             onClicked: () =>
@@ -2193,7 +2195,7 @@ let createConfigMenu = () =>
                         }),
                         ui.createButton
                         ({
-                            text: getLoc('defaultButton'),
+                            text: getLoc('btnDefault'),
                             row: 0,
                             column: 1,
                             onClicked: () =>
@@ -2265,7 +2267,7 @@ let createSystemMenu = () =>
     });
     let addRuleButton = ui.createButton
     ({
-        text: getLoc('addButton'),
+        text: getLoc('btnAdd'),
         row: 0,
         column: 1,
         // heightRequest: 40,
@@ -2309,7 +2311,7 @@ let createSystemMenu = () =>
 
     let menu = ui.createPopup
     ({
-        title: getLoc('sysMenuTitle'),
+        title: getLoc('menuLSystem'),
         content: ui.createStackLayout
         ({
             children:
@@ -2327,7 +2329,7 @@ let createSystemMenu = () =>
                                 [
                                     ui.createLatexLabel
                                     ({
-                                        text: getLoc('axiomLabel'),
+                                        text: getLoc('labelAxiom'),
                                         row: 0,
                                         column: 0,
                                         verticalOptions: LayoutOptions.CENTER
@@ -2335,7 +2337,7 @@ let createSystemMenu = () =>
                                     axiomEntry,
                                     ui.createLatexLabel
                                     ({
-                                        text: getLoc('angleLabel'),
+                                        text: getLoc('labelAngle'),
                                         row: 0,
                                         column: 2,
                                         verticalOptions: LayoutOptions.CENTER
@@ -2350,7 +2352,7 @@ let createSystemMenu = () =>
                                 [
                                     ui.createLatexLabel
                                     ({
-                                        text: getLoc('rulesLabel'),
+                                        text: getLoc('labelRules'),
                                         verticalOptions: LayoutOptions.CENTER,
                                         margin: new Thickness(0, 6)
                                     }),
@@ -2365,7 +2367,7 @@ let createSystemMenu = () =>
                                 [
                                     ui.createLatexLabel
                                     ({
-                                        text: getLoc('ignoreLabel'),
+                                        text: getLoc('labelIgnored'),
                                         row: 0,
                                         column: 0,
                                         verticalOptions: LayoutOptions.CENTER
@@ -2373,7 +2375,7 @@ let createSystemMenu = () =>
                                     ignoreEntry,
                                     ui.createLatexLabel
                                     ({
-                                        text: getLoc('seedLabel'),
+                                        text: getLoc('labelSeed'),
                                         row: 1,
                                         column: 0,
                                         verticalOptions: LayoutOptions.CENTER
@@ -2391,7 +2393,7 @@ let createSystemMenu = () =>
                 }),
                 ui.createButton
                 ({
-                    text: getLoc('constructButton'),
+                    text: getLoc('btnConstruct'),
                     onClicked: () =>
                     {
                         Sound.playClick();
@@ -2419,7 +2421,7 @@ let createNamingMenu = (title, values) =>
     });
     let menu = ui.createPopup
     ({
-        title: getLoc('namingMenuTitle'),
+        title: getLoc('menuNaming'),
         content: ui.createStackLayout
         ({
             children:
@@ -2432,7 +2434,7 @@ let createNamingMenu = (title, values) =>
                 }),
                 ui.createButton
                 ({
-                    text: getLoc('saveButton'),
+                    text: getLoc('btnSave'),
                     onClicked: () =>
                     {
                         Sound.playClick();
@@ -2461,7 +2463,7 @@ let createClipboardMenu = (values) =>
     });
     let menu = ui.createPopup
     ({
-        title: getLoc('clipboardMenuTitle'),
+        title: getLoc('menuClipboard'),
         content: ui.createStackLayout
         ({
             children:
@@ -2474,7 +2476,7 @@ let createClipboardMenu = (values) =>
                 }),
                 ui.createButton
                 ({
-                    text: getLoc('constructButton'),
+                    text: getLoc('btnConstruct'),
                     onClicked: () =>
                     {
                         Sound.playClick();
@@ -2543,7 +2545,7 @@ let createViewMenu = (title) =>
                                 [
                                     ui.createLatexLabel
                                     ({
-                                        text: getLoc('axiomLabel'),
+                                        text: getLoc('labelAxiom'),
                                         row: 0,
                                         column: 0,
                                         verticalOptions: LayoutOptions.CENTER
@@ -2556,7 +2558,7 @@ let createViewMenu = (title) =>
                                     }),
                                     ui.createLatexLabel
                                     ({
-                                        text: getLoc('angleLabel'),
+                                        text: getLoc('labelAngle'),
                                         row: 0,
                                         column: 2,
                                         verticalOptions: LayoutOptions.CENTER
@@ -2573,7 +2575,7 @@ let createViewMenu = (title) =>
                             }),
                             ui.createLatexLabel
                             ({
-                                text: getLoc('rulesLabel'),
+                                text: getLoc('labelRules'),
                                 verticalOptions: LayoutOptions.CENTER,
                                 margin: new Thickness(0, 6)
                             }),
@@ -2588,7 +2590,7 @@ let createViewMenu = (title) =>
                                 [
                                     ui.createLatexLabel
                                     ({
-                                        text: getLoc('ignoreLabel'),
+                                        text: getLoc('labelIgnored'),
                                         row: 0,
                                         column: 0,
                                         verticalOptions: LayoutOptions.CENTER
@@ -2601,7 +2603,7 @@ let createViewMenu = (title) =>
                                     }),
                                     ui.createLatexLabel
                                     ({
-                                        text: getLoc('seedLabel'),
+                                        text: getLoc('labelSeed'),
                                         row: 1,
                                         column: 0,
                                         verticalOptions: LayoutOptions.CENTER
@@ -2632,7 +2634,7 @@ let createViewMenu = (title) =>
                     [
                         ui.createButton
                         ({
-                            text: getLoc('constructButton'),
+                            text: getLoc('btnConstruct'),
                             row: 0,
                             column: 0,
                             onClicked: () =>
@@ -2645,7 +2647,7 @@ let createViewMenu = (title) =>
                         }),
                         ui.createButton
                         ({
-                            text: getLoc('deleteButton'),
+                            text: getLoc('btnDelete'),
                             row: 0,
                             column: 1,
                             onClicked: () =>
@@ -2691,7 +2693,7 @@ let createSaveMenu = () =>
     {
         let btn = ui.createButton
         ({
-            text: getLoc('viewButton'),
+            text: getLoc('btnView'),
             row: 0,
             column: 1,
             // heightRequest: 40,
@@ -2716,7 +2718,7 @@ let createSaveMenu = () =>
 
     menu = ui.createPopup
     ({
-        title: getLoc('saveMenuTitle'),
+        title: getLoc('menuSave'),
         content: ui.createStackLayout
         ({
             children:
@@ -2735,7 +2737,7 @@ let createSaveMenu = () =>
                         }),
                         ui.createButton
                         ({
-                            text: getLoc('clipboardButton'),
+                            text: getLoc('btnClipboard'),
                             row: 0,
                             column: 1,
                             onClicked: () =>
@@ -2747,7 +2749,7 @@ let createSaveMenu = () =>
                         }),
                         ui.createButton
                         ({
-                            text: getLoc('saveButton'),
+                            text: getLoc('btnSave'),
                             row: 0,
                             column: 2,
                             // heightRequest: 40,
@@ -2809,7 +2811,7 @@ let createManualMenu = () =>
 
     let menu = ui.createPopup
     ({
-        title: Localization.format(getLoc('manualMenuTitle'), page + 1,
+        title: Localization.format(getLoc('menuManual'), page + 1,
         getLoc('manual').length),
         content: ui.createStackLayout
         ({
@@ -2837,7 +2839,7 @@ let createManualMenu = () =>
                     [
                         ui.createButton
                         ({
-                            text: getLoc('prevButton'),
+                            text: getLoc('btnPrev'),
                             row: 0,
                             column: 0,
                             isVisible: () => page > 0,
@@ -2848,7 +2850,7 @@ let createManualMenu = () =>
                                     Sound.playClick();
                                     --page;
                                     menu.title = Localization.format(
-                                        getLoc('manualMenuTitle'), page + 1,
+                                        getLoc('menuManual'), page + 1,
                                         getLoc('manual').length
                                     );
                                     pageTitle.text = manualPages[page].title;
@@ -2859,7 +2861,7 @@ let createManualMenu = () =>
                         }),
                         ui.createButton
                         ({
-                            text: getLoc('constructButton'),
+                            text: getLoc('btnConstruct'),
                             row: 0,
                             column: 1,
                             isVisible: () => 'system' in manualSystems[page],
@@ -2878,7 +2880,7 @@ let createManualMenu = () =>
                         }),
                         ui.createButton
                         ({
-                            text: getLoc('nextButton'),
+                            text: getLoc('btnNext'),
                             row: 0,
                             column: 2,
                             isVisible: () => page < manualPages.length - 1,
@@ -2889,7 +2891,7 @@ let createManualMenu = () =>
                                 {
                                     ++page;
                                     menu.title = Localization.format(
-                                        getLoc('manualMenuTitle'), page + 1,
+                                        getLoc('menuManual'), page + 1,
                                         getLoc('manual').length
                                     );
                                     pageTitle.text = manualPages[page].title;
@@ -2913,7 +2915,7 @@ let createSequenceMenu = () =>
     {
         tmpLvls.push(ui.createLatexLabel
         ({
-            text: Localization.format(getLoc('lvlLabel'), i),
+            text: Localization.format(getLoc('labelLevelSeq'), i),
             row: i,
             column: 0,
             verticalOptions: LayoutOptions.CENTER
@@ -2933,7 +2935,7 @@ let createSequenceMenu = () =>
 
     let menu = ui.createPopup
     ({
-        title: getLoc('seqMenuTitle'),
+        title: getLoc('menuSequence'),
         content: ui.createStackLayout
         ({
             children:
@@ -2950,7 +2952,7 @@ let createSequenceMenu = () =>
                 }),
                 ui.createButton
                 ({
-                    text: getLoc('closeButton'),
+                    text: getLoc('btnClose'),
                     onClicked: () =>
                     {
                         Sound.playClick();
@@ -2986,7 +2988,7 @@ let createWorldMenu = () =>
     let tmpAC = altCurrencies;
     let ACLabel = ui.createLatexLabel
     ({
-        text: Localization.format(getLoc('ACLabel'),
+        text: Localization.format(getLoc('labelTerEq'),
         getLoc('terEqModes')[Number(tmpAC)]),
         row: 1,
         column: 0,
@@ -3006,7 +3008,7 @@ let createWorldMenu = () =>
                 Sound.playClick();
                 tmpAC = !tmpAC;
                 ACSwitch.isToggled = tmpAC;
-                ACLabel.text = Localization.format(getLoc('ACLabel'),
+                ACLabel.text = Localization.format(getLoc('labelTerEq'),
                 getLoc('terEqModes')[Number(tmpAC)]);
             }
         }
@@ -3014,7 +3016,7 @@ let createWorldMenu = () =>
 
     let menu = ui.createPopup
     ({
-        title: getLoc('worldMenuTitle'),
+        title: getLoc('menuTheory'),
         content: ui.createStackLayout
         ({
             children:
@@ -3026,7 +3028,7 @@ let createWorldMenu = () =>
                     [
                         ui.createLatexLabel
                         ({
-                            text: getLoc('ODLabel'),
+                            text: getLoc('labelOfflineDrawing'),
                             row: 0,
                             column: 0,
                             verticalOptions: LayoutOptions.CENTER
@@ -3043,7 +3045,7 @@ let createWorldMenu = () =>
                 }),
                 ui.createButton
                 ({
-                    text: getLoc('saveButton'),
+                    text: getLoc('btnSave'),
                     onClicked: () =>
                     {
                         Sound.playClick();

--- a/renderer.js
+++ b/renderer.js
@@ -1370,7 +1370,7 @@ var tick = (elapsedTime, multiplier) =>
         renderer.draw(l.level, true);
     }
 
-    if(ts.level > 0)
+    if(ts.level > 0 && (!gameIsOffline || offlineDrawing))
         renderer.tick(elapsedTime);
     let msTime = renderer.getElapsedTime();
     min.value = msTime[0] + msTime[1] / 100;
@@ -1605,13 +1605,13 @@ var getUpgradeListDelegate = () =>
     let expButton = createMenuButton(createSaveMenu, 'Save/load', height);
     expButton.row = 1;
     expButton.column = 0;
-    let manualButton = createMenuButton(createManualMenu, 'Manual', height);
-    manualButton.row = 1;
-    manualButton.column = 1;
     let worldButton = createMenuButton(createWorldMenu, 'Theory settings',
     height);
-    worldButton.row = 2;
-    worldButton.column = 0;
+    worldButton.row = 1;
+    worldButton.column = 1;
+    let manualButton = createMenuButton(createManualMenu, 'Manual', height);
+    manualButton.row = 2;
+    manualButton.column = 0;
 
     let stack = ui.createScrollView
     ({

--- a/renderer.js
+++ b/renderer.js
@@ -1183,7 +1183,7 @@ var createConfigMenu = () =>
     let tmpOD = renderer.loopMode;
     let ODSwitch = ui.createSwitch
     ({
-        isToggled: tmpOD,
+        isToggled: Boolean(tmpOD),
         row: 0,
         column: 1,
         horizontalOptions: LayoutOptions.END,
@@ -2020,15 +2020,19 @@ var createManualMenu = () =>
             children:
             [
                 pageTitle,
-                ui.createBox
+                // ui.createBox
+                // ({
+                //     heightRequest: 1,
+                //     margin: new Thickness(0, 6)
+                // }),
+                ui.createFrame
                 ({
-                    heightRequest: 1,
-                    margin: new Thickness(0, 6)
-                }),
-                ui.createScrollView
-                ({
+                    padding: new Thickness(6, 6),
                     heightRequest: ui.screenHeight * 0.3,
-                    content: pageContents
+                    content: ui.createScrollView
+                    ({
+                        content: pageContents
+                    })
                 }),
                 ui.createBox
                 ({


### PR DESCRIPTION
0.19, representing the winter equivalent of a spring cleaning, is coming. This update focuses on Quality of Life changes.

New features:
- Looping modes: once, level, playlist (consecutive)
- New 'Theory settings' menu:
  - Offline drawing
  - Reset level on construction
  - Tertiary equation display
- Dynamic loading - it even draws while loading the same level!
- Elapsed time, located on the currency bar
- Level 'anchoring' on the tickspeed variable
- The manual has a frame now.

Plus a bunch of bug fixes and internal cleaning:
- Localisations are now possible! - they are recorded in a global object
- Docstrings on the classes
- Improved loop processing to guard against user input errors (in rules)
- Improved internal state processing to guard against corruption
- Manual entries in code are now written with graves
- Changed 'Apply' button names to 'Construct'
- Quaternion members changed from wxyz to rijk